### PR TITLE
[JENKINS-33110] Log details not shown

### DIFF
--- a/ui/src/main/js/view/stage-logs.js
+++ b/ui/src/main/js/view/stage-logs.js
@@ -54,20 +54,12 @@ exports.render = function (stageDescription, onElement) {
                     var nodeLogFrame = nodeNameBar.parent();
                     var active = nodeLogFrame.hasClass('active');
 
-                    // remove active state from all log frames
-                    nodeLogFrames.removeClass('active');
-                    nodeLogFrames.removeClass('inactive');
-
                     // add active state to the clicked log frame if was previously inactive
                     if (!active) {
-                        nodeLogFrames.addClass('inactive');
-                        nodeLogFrame.removeClass('inactive');
+                        // Hide any other log box
+                        nodeLogFrames.removeClass('active');
+                        // Show this one
                         nodeLogFrame.addClass('active');
-
-                        // set the height of the log-details window so it scrolls properly
-                        var logDetails = $('.log-details', nodeLogFrame);
-                        var position = logDetails.position();
-                        logDetails.height(dialogHeight - header.outerHeight() - position.top - (parseFloat(stageLogsDom.css("border-bottom-width")) * 2));
                     }
                 });
 

--- a/ui/src/main/js/view/templates/stage-logs.hbs
+++ b/ui/src/main/js/view/templates/stage-logs.hbs
@@ -2,7 +2,7 @@
     {{#each stageFlowNodes}}
         {{#if this._links.log.href}}
         <div class="node-log-frame {{this.status}}" cbwf-controller="node-log" objectUrl="{{this._links.log.href}}">
-            <div class="node-name"><span class="glyphicon glyphicon-collapse-down" title="Expand"></span><span class="glyphicon glyphicon-collapse-up" title="Collapse"></span> {{this.name}} <a class="show-all" href="#">(show all steps)</a></div>
+            <div class="node-name"><span class="glyphicon glyphicon-collapse-down" title="Expand"></span><span class="glyphicon glyphicon-collapse-up" title="Collapse"></span> {{this.name}}</div>
             <div class="log-details"></div>
         </div>
         {{/if}}

--- a/ui/src/main/js/view/templates/stage-logs.less
+++ b/ui/src/main/js/view/templates/stage-logs.less
@@ -28,7 +28,9 @@
     box-shadow:inset rgba(0,0,0,.2) 0 1px 2px,inset rgba(0,0,0,.2) 0 0 0 1px, inset rgba(255,255,255,.2) 0 0 0 99em;
 
     .console-output{
-      padding:15px;
+      padding: 20px 15px;
+      margin: 0;
+      border-radius: 0;
       line-height:20px;
       box-shadow:inset rgba(0,0,0,.1) -1px 0 0;
       background:repeating-linear-gradient(

--- a/ui/src/main/js/view/templates/stage-logs.less
+++ b/ui/src/main/js/view/templates/stage-logs.less
@@ -19,6 +19,7 @@
   }
 
   .log-details {
+    max-height: 400px;
     overflow: auto;
     display: none;
     color:rgba(0,0,0,.67);

--- a/ui/src/test/js/view/stage-logs-spec.js
+++ b/ui/src/test/js/view/stage-logs-spec.js
@@ -76,6 +76,7 @@ describe("view/stage-logs", function () {
 
             // logDetails of that log should be filled in...
             expect($('.log-details .console-output', firstLogNode).text()).toBe('build');
+            expect($('.log-details .console-output', firstLogNode).is(':visible')).toBe(true);
 
             // console.log($('body').html());
 


### PR DESCRIPTION
[JENKINS-33110](https://issues.jenkins-ci.org/browse/JENKINS-33110)

- [x] Expand log sections on click (regression)
- [x] When there are more than 15-20 steps in the same stage the log is not shown for last steps in the list (the calculation of the height was overlapping previous layers in the DOM)
- [x] Adjust the log DOM container to its parent element and make the lines match with the background
- [x] Test

@reviewbybees esp. @tfennelly @recena