### PR TITLE
Dependency fixes II

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,6 +47,7 @@
 
     <properties>
         <jenkins.version>1.609.3</jenkins.version>
+        <java.level>6</java.level>
         <workflow.version>1.14</workflow.version>
         <jenkins-test-harness.version>2.1</jenkins-test-harness.version>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>2.3</version>
+        <version>2.5</version>
     </parent>
 
     <groupId>org.jenkins-ci.plugins.pipeline-stage-view</groupId>

--- a/rest-api/pom.xml
+++ b/rest-api/pom.xml
@@ -56,6 +56,12 @@
             <version>${workflow.version}</version>
         </dependency>
         <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>pipeline-input-step</artifactId>
+            <version>2.0</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-basic-steps</artifactId>
             <version>${workflow.version}</version>

--- a/rest-api/pom.xml
+++ b/rest-api/pom.xml
@@ -127,6 +127,25 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>display-info</id>
+                        <configuration>
+                            <rules>
+                                <enforceBytecodeVersion>
+                                    <excludes combine.children="append">
+                                        <exclude>org.jenkins-ci.plugins:pipeline-input-step</exclude> <!-- if you are running it, this is Java 7 -->
+                                        <exclude>org.jenkins-ci.plugins.workflow:workflow-step-api</exclude> <!-- seems to be pulled in from the above -->
+                                        <exclude>org.jenkins-ci.plugins.workflow:workflow-support</exclude> <!-- ditto -->
+                                    </excludes>
+                                </enforceBytecodeVersion>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 

--- a/rest-api/pom.xml
+++ b/rest-api/pom.xml
@@ -72,6 +72,7 @@
             <artifactId>workflow-support</artifactId>
             <version>${workflow.version}</version>
             <classifier>tests</classifier>
+            <scope>test</scope>
         </dependency>
 
         <!-- May be able to remove these due to core -->

--- a/ui/gulpfile.js
+++ b/ui/gulpfile.js
@@ -46,3 +46,4 @@ builder.bundle('src/main/js/stageview.js')
 // Explicitly setting the task list so as to disable jshint
 // TODO: Remove the line below + fix jshint build errors
 builder.defineTasks(['test', 'bundle', 'rebundle']);
+builder.defineTask('lint', function() {}); // https://github.com/jenkinsci/plugin-pom/pull/20#issuecomment-206374472

--- a/ui/pom.xml
+++ b/ui/pom.xml
@@ -54,38 +54,34 @@
             <groupId>${project.groupId}</groupId>
             <artifactId>pipeline-rest-api</artifactId>
             <version>${project.version}</version>
-            <type>hpi</type>
         </dependency>
         <dependency>
-            <groupId>${project.groupId}</groupId>
-            <artifactId>pipeline-rest-api</artifactId>
-            <version>${project.version}</version>
-            <scope>test</scope>
+            <groupId>org.jenkins-ci.plugins.workflow</groupId>
+            <artifactId>workflow-job</artifactId>
+            <version>${workflow.version}</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-aggregator</artifactId>
             <version>${workflow.version}</version>
             <classifier>tests</classifier>
+            <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.jenkins-ci.ui</groupId>
             <artifactId>jquery-detached</artifactId>
             <version>1.1.1</version>
-            <type>hpi</type>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.ui</groupId>
             <artifactId>handlebars</artifactId>
             <version>1.1</version>
-            <type>hpi</type>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.ui</groupId>
             <artifactId>momentjs</artifactId>
             <version>1.1</version>
-            <type>hpi</type>
         </dependency>
         <dependency>
             <groupId>com.github.detro.ghostdriver</groupId>


### PR DESCRIPTION
Less-intrusive variant of #7. From CD demo, fixes

```
… org.eclipse.jetty.util.log.JavaUtilLog warn
WARNING: Error while serving …/wfapi/runs
java.lang.reflect.InvocationTargetException
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.kohsuke.stapler.Function$InstanceFunction.invoke(Function.java:298)
	at com.cloudbees.workflow.util.ServeJson$Processor.invoke(ServeJson.java:29)
	at …
Caused by: java.lang.NoClassDefFoundError: org/jenkinsci/plugins/workflow/support/steps/input/InputAction
	at com.cloudbees.workflow.rest.external.RunExt.isPendingInput(RunExt.java:259)
	at com.cloudbees.workflow.rest.external.RunExt.initStatus(RunExt.java:278)
	at com.cloudbees.workflow.rest.external.RunExt.create(RunExt.java:196)
	at com.cloudbees.workflow.rest.external.JobExt.create(JobExt.java:124)
	at com.cloudbees.workflow.rest.endpoints.JobAPI.doRuns(JobAPI.java:68)
	... 67 more
Caused by: java.lang.ClassNotFoundException: org.jenkinsci.plugins.workflow.support.steps.input.InputAction
	at jenkins.util.AntClassLoader.findClassInComponents(AntClassLoader.java:1376)
	at jenkins.util.AntClassLoader.findClass(AntClassLoader.java:1326)
	at jenkins.util.AntClassLoader.loadClass(AntClassLoader.java:1079)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:357)
	... 72 more
```

when showing the stage view.

@reviewbybees esp. @svanoort