### PR TITLE
Grabbag of small fixes

### DIFF
--- a/rest-api/src/main/java/com/cloudbees/workflow/rest/external/BuildArtifactExt.java
+++ b/rest-api/src/main/java/com/cloudbees/workflow/rest/external/BuildArtifactExt.java
@@ -85,6 +85,13 @@ public class BuildArtifactExt {
 
         inputActionExt.setId(artifact.getTreeNodeId());
         inputActionExt.setName(artifact.getDisplayPath());
+
+        // DisplayPath does some custom processing to handle collisions, but isn't set if we have more than
+        // Run.LIST_CUTOFF artifacts - since we're just using this for display, relativePath is good enough
+        String nameCandidate = artifact.getDisplayPath();
+        inputActionExt.setName(
+                (nameCandidate != null) ? nameCandidate : artifact.relativePath
+        );
         inputActionExt.setPath(artifact.getHref());
         inputActionExt.setUrl(RunAPI.getArtifactUrl(run, artifact));
         inputActionExt.setSize(artifact.getFileSize());

--- a/ui/src/main/js/util/formatters.js
+++ b/ui/src/main/js/util/formatters.js
@@ -23,9 +23,9 @@
  */
 
 var KB = 1024;
-var MB = KB * 1000;
-var GB = MB * 1000;
-var TB = GB * 1000;
+var MB = KB * 1024;
+var GB = MB * 1024;
+var TB = GB * 1024;
 
 var sec = 1000;
 var min = sec * 60;

--- a/ui/src/main/js/view/remove-sidepanel.js
+++ b/ui/src/main/js/view/remove-sidepanel.js
@@ -27,4 +27,5 @@ var jqProxy = require('../jQuery');
 exports.render = function (message, onElement) {
     var $ = jqProxy.getJQuery();
     $('div#side-panel').remove();
+    $('div#main-panel').addClass("fullscreen");
 }

--- a/ui/src/main/less/stageview_adjunct.less
+++ b/ui/src/main/less/stageview_adjunct.less
@@ -9,6 +9,11 @@
   @import "bootstrap";
 }
 
+div.fullscreen#main-panel {
+  margin-left: 15px;
+  padding-left: 0;
+}
+
 @import "./variables";
 @import "./mixins";
 @import "./icons";


### PR DESCRIPTION
* Solves  [JENKINS-33498](https://issues.jenkins-ci.org/browse/JENKINS-33498) by CSS changes + adding class to the fullscreen view main-panel. 
* Solves [JENKINS-33351](https://issues.jenkins-ci.org/browse/JENKINS-33351) by using relativePath when too many artifacts are set to generate displayPaths (API fix).
* Solve [JENKINS-33714](https://issues.jenkins-ci.org/browse/JENKINS-33714) - Correctly calculate the prefixes for data size