### PR TITLE
Fix flow node links when used with no Stapler request

### DIFF
--- a/rest-api/src/main/java/com/cloudbees/workflow/rest/external/FlowNodeExt.java
+++ b/rest-api/src/main/java/com/cloudbees/workflow/rest/external/FlowNodeExt.java
@@ -167,10 +167,8 @@ public class FlowNodeExt {
         setId(node.getId());
         setName(node.getDisplayName());
         setExecNode(execNodeName);
-        if (Stapler.getCurrentRequest() != null) {
-            set_links(new FlowNodeLinks());
-            get_links().initSelf(Describe.getUrl(node));
-        }
+        set_links(new FlowNodeLinks());
+        get_links().initSelf(Describe.getUrl(node));
         setStatus(status);
         if (status != StatusExt.NOT_EXECUTED) {
             setError(ErrorExt.create(error));


### PR DESCRIPTION
Integrating with other plugins that need to get a JSON representation of the
pipeline state there is no Stapler request. Currently this throws an NPE which
this fixes.