### PR TITLE
Fix log popup placement [JENKINS-33109]

### DIFF
--- a/ui/src/main/js/view/stage-logs.js
+++ b/ui/src/main/js/view/stage-logs.js
@@ -31,7 +31,7 @@ exports.render = function (stageDescription, onElement) {
     var stageLogsDom = templates.apply('stage-logs', stageDescription);
     var winWidth = $(theWindow).width();
     var winHeight = $(theWindow).height();
-    var dialogWidth = Math.min(800, (winWidth * 0.5));
+    var dialogWidth = Math.min(800, (winWidth * 0.7));
     var dialogHeight = Math.min(800, (winHeight * 0.7));
     var nodeLogFrames = $('.node-log-frame', stageLogsDom);
     var nodeNameBars = $('.node-name', stageLogsDom);
@@ -44,8 +44,8 @@ exports.render = function (stageDescription, onElement) {
     onElement.on(clickNSEvent, function() {
         dialog.show('Stage Logs (' + stageDescription.name + ')', stageLogsDom, {
             classes: 'cbwf-stage-logs-dialog',
-            placement: 'over-element',
-            'onElement': onElement,
+            placement: 'window-visible-top',
+            onElement: onElement,
             width: dialogWidth,
             height: dialogHeight,
             onshow: function() {

--- a/ui/src/main/js/view/stage-logs.js
+++ b/ui/src/main/js/view/stage-logs.js
@@ -31,7 +31,7 @@ exports.render = function (stageDescription, onElement) {
     var stageLogsDom = templates.apply('stage-logs', stageDescription);
     var winWidth = $(theWindow).width();
     var winHeight = $(theWindow).height();
-    var dialogWidth = Math.min(800, (winWidth * 0.7));
+    var dialogWidth = Math.min(800, (winWidth * 0.5));
     var dialogHeight = Math.min(800, (winHeight * 0.7));
     var nodeLogFrames = $('.node-log-frame', stageLogsDom);
     var nodeNameBars = $('.node-name', stageLogsDom);
@@ -44,6 +44,8 @@ exports.render = function (stageDescription, onElement) {
     onElement.on(clickNSEvent, function() {
         dialog.show('Stage Logs (' + stageDescription.name + ')', stageLogsDom, {
             classes: 'cbwf-stage-logs-dialog',
+            placement: 'right',
+            'onElement': onElement,
             width: dialogWidth,
             height: dialogHeight,
             onshow: function() {

--- a/ui/src/main/js/view/stage-logs.js
+++ b/ui/src/main/js/view/stage-logs.js
@@ -44,7 +44,7 @@ exports.render = function (stageDescription, onElement) {
     onElement.on(clickNSEvent, function() {
         dialog.show('Stage Logs (' + stageDescription.name + ')', stageLogsDom, {
             classes: 'cbwf-stage-logs-dialog',
-            placement: 'right',
+            placement: 'over-element',
             'onElement': onElement,
             width: dialogWidth,
             height: dialogHeight,

--- a/ui/src/main/js/view/widgets/dialog/index.js
+++ b/ui/src/main/js/view/widgets/dialog/index.js
@@ -59,13 +59,8 @@ exports.show = function(title, body, options) {
     bodyEl.append(body);
 
     options.modal = true;
-    // Undefined for the onElement makes it in the window center
-    // WE NEED an onElement, but right now this fails
-    if (options.onElement) {
-        var popover = popoverWidget.newPopover(title, dialog, options.onElement, options);
-    } else {
-        var popover = popoverWidget.newPopover(title, dialog, undefined, options);
-    } 
+    // Undefined for the onElement makes it in the window center, otherwise it needs it for positioning
+    var popover = popoverWidget.newPopover(title, dialog, options.onElement, options);
 
     popover.show();
     if (options.onshow) {

--- a/ui/src/main/js/view/widgets/dialog/index.js
+++ b/ui/src/main/js/view/widgets/dialog/index.js
@@ -59,7 +59,14 @@ exports.show = function(title, body, options) {
     bodyEl.append(body);
 
     options.modal = true;
-    var popover = popoverWidget.newPopover(title, dialog, undefined, options);
+    // Undefined for the onElement makes it in the window center
+    // WE NEED an onElement, but right now this fails
+    if (options.onElement) {
+        var popover = popoverWidget.newPopover(title, dialog, options.onElement, options);
+    } else {
+        var popover = popoverWidget.newPopover(title, dialog, undefined, options);
+    } 
+
     popover.show();
     if (options.onshow) {
         options.onshow();

--- a/ui/src/main/js/view/widgets/popover/index.js
+++ b/ui/src/main/js/view/widgets/popover/index.js
@@ -318,7 +318,7 @@ Popover.prototype.applyPlacement = function() {
             'top': onElementOffset.top,
             'left': onElementOffset.left + thisPopover.onElement.width() + 5
         });
-    } else if (placement === 'over-element') {  // centered on element and just above
+    } else if (placement === 'centered-above-element') {  // centered in window element and just above
         var winWidth = $(theWindow).width();
         var popoverWidth = thisPopover.popover.width();
 
@@ -329,7 +329,7 @@ Popover.prototype.applyPlacement = function() {
             'top': topPlacement,
             'left': leftPlacement
         });
-    } else if (placement === 'left') {
+    }  else if (placement === 'left') {
         var onElementOffset = thisPopover.onElement.offset();
         thisPopover.popover.css({
             'top': onElementOffset.top,
@@ -353,6 +353,16 @@ Popover.prototype.applyPlacement = function() {
         // try not have the top of the dialog further down from the
         // top thn 1/4 the window height.
         topPlacement = Math.min(topPlacement, (winWidth / 4));
+
+        thisPopover.popover.css({
+            'top': topPlacement,
+            'left': leftPlacement
+        });
+    } else if (placement === 'window-visible-top') { // Centered at top of visible window
+        var winWidth = $(theWindow).width();
+        var popoverWidth = thisPopover.popover.width();
+        var leftPlacement = ((winWidth - popoverWidth) / 2);
+        var topPlacement = window.scrollY + 20;
 
         thisPopover.popover.css({
             'top': topPlacement,

--- a/ui/src/main/js/view/widgets/popover/index.js
+++ b/ui/src/main/js/view/widgets/popover/index.js
@@ -318,6 +318,17 @@ Popover.prototype.applyPlacement = function() {
             'top': onElementOffset.top,
             'left': onElementOffset.left + thisPopover.onElement.width() + 5
         });
+    } else if (placement === 'over-element') {  // centered on element and just above
+        var winWidth = $(theWindow).width();
+        var popoverWidth = thisPopover.popover.width();
+
+        var leftPlacement = ((winWidth - popoverWidth) / 2);
+        var topPlacement = thisPopover.onElement.offset().top - 50;
+
+        thisPopover.popover.css({
+            'top': topPlacement,
+            'left': leftPlacement
+        });
     } else if (placement === 'left') {
         var onElementOffset = thisPopover.onElement.offset();
         thisPopover.popover.css({

--- a/ui/src/main/js/view/widgets/popover/index.js
+++ b/ui/src/main/js/view/widgets/popover/index.js
@@ -318,17 +318,6 @@ Popover.prototype.applyPlacement = function() {
             'top': onElementOffset.top,
             'left': onElementOffset.left + thisPopover.onElement.width() + 5
         });
-    } else if (placement === 'centered-above-element') {  // centered in window element and just above
-        var winWidth = $(theWindow).width();
-        var popoverWidth = thisPopover.popover.width();
-
-        var leftPlacement = ((winWidth - popoverWidth) / 2);
-        var topPlacement = thisPopover.onElement.offset().top - 50;
-
-        thisPopover.popover.css({
-            'top': topPlacement,
-            'left': leftPlacement
-        });
     }  else if (placement === 'left') {
         var onElementOffset = thisPopover.onElement.offset();
         thisPopover.popover.css({

--- a/ui/src/main/js/view/widgets/popover/index.js
+++ b/ui/src/main/js/view/widgets/popover/index.js
@@ -351,7 +351,11 @@ Popover.prototype.applyPlacement = function() {
         var winWidth = $(theWindow).width();
         var popoverWidth = thisPopover.popover.width();
         var leftPlacement = ((winWidth - popoverWidth) / 2);
-        var topPlacement = window.scrollY + 20;
+
+        var topPlacement = 20;  // For tests, which don't have a window
+        if (typeof window !== 'undefined') {
+            topPlacement = window.scrollY + 20;
+        }
 
         thisPopover.popover.css({
             'top': topPlacement,

--- a/ui/src/main/js/view/widgets/popover/index.js
+++ b/ui/src/main/js/view/widgets/popover/index.js
@@ -318,7 +318,7 @@ Popover.prototype.applyPlacement = function() {
             'top': onElementOffset.top,
             'left': onElementOffset.left + thisPopover.onElement.width() + 5
         });
-    }  else if (placement === 'left') {
+    } else if (placement === 'left') {
         var onElementOffset = thisPopover.onElement.offset();
         thisPopover.popover.css({
             'top': onElementOffset.top,

--- a/ui/src/test/js/util/formatters-spec.js
+++ b/ui/src/test/js/util/formatters-spec.js
@@ -17,9 +17,9 @@ describe("util/formatters-spec", function () {
         expect(formatters.memory(1)).toBe('1B');
         expect(formatters.memory(999)).toBe('999B');
         expect(formatters.memory(1999)).toBe('1.95KB');
-        expect(formatters.memory(1999999)).toBe('1.95MB');
-        expect(formatters.memory(1999999999)).toBe('1.95GB');
-        expect(formatters.memory(1999999999999)).toBe('1.95TB');
+        expect(formatters.memory(1999999)).toBe('1.91MB');
+        expect(formatters.memory(1999999999)).toBe('1.86GB');
+        expect(formatters.memory(1999999999999)).toBe('1.82TB');
     });
 
     it("- test_time_default", function () {


### PR DESCRIPTION
This fixes the log window popup placement from [JENKINS-33109](https://issues.jenkins-ci.org/browse/JENKINS-33109) and makes the window placement more natural when users have scrolled down a list of stages.

This places the popup for logs centered at the top of the visible area (a natural placement).  It also adds information about the element triggering the popup (which can be used to modify placement if desired). 

@reviewbybees 