### PR TITLE
Properties to configure hardcoded limits on APIs - JENKINS-34791

### DIFF
--- a/rest-api/src/main/java/com/cloudbees/workflow/rest/external/FlowNodeLogExt.java
+++ b/rest-api/src/main/java/com/cloudbees/workflow/rest/external/FlowNodeLogExt.java
@@ -39,7 +39,7 @@ import java.util.logging.Logger;
  */
 public class FlowNodeLogExt {
 
-    private static long MAX_RETURN_CHARS = 10 * 1024;
+    private static long MAX_RETURN_CHARS = Integer.getInteger(FlowNodeLogExt.class.getName()+".maxReturnChars", 10 * 1024);
 
     private static final Logger LOGGER = Logger.getLogger(FlowNodeLogExt.class.getName());
 

--- a/rest-api/src/main/java/com/cloudbees/workflow/rest/external/JobExt.java
+++ b/rest-api/src/main/java/com/cloudbees/workflow/rest/external/JobExt.java
@@ -42,7 +42,7 @@ public class JobExt {
     /**
      * Max number of runs per page. Pagination not yet supported.
      */
-    public static final int RUN_PAGE_SIZE = 20;
+    public static final int MAX_RUNS_PER_JOB = Integer.getInteger(JobExt.class.getName()+".maxRunsPerJob", 10);
 
     private JobLinks _links;
     private String name;
@@ -127,7 +127,7 @@ public class JobExt {
             runsExt.add(runExt);
             if (since != null && runExt.getName().equals(since)) {
                 break;
-            } else if (runsExt.size() > RUN_PAGE_SIZE) {
+            } else if (runsExt.size() > MAX_RUNS_PER_JOB) {
                 // We don't yet support pagination, so no point
                 // returning a huge list of runs.
                 break;

--- a/rest-api/src/main/java/com/cloudbees/workflow/rest/external/RunExt.java
+++ b/rest-api/src/main/java/com/cloudbees/workflow/rest/external/RunExt.java
@@ -49,7 +49,7 @@ import java.util.List;
  */
 public class RunExt {
 
-    private static final int MAX_ARTIFACTS_COUNT = 100;
+    private static int MAX_ARTIFACTS_COUNT = Integer.getInteger(RunExt.class.getName()+".maxArtifactsCount", 100);
 
     private RunLinks _links;
     private String id;

--- a/rest-api/src/main/java/com/cloudbees/workflow/rest/external/StageNodeExt.java
+++ b/rest-api/src/main/java/com/cloudbees/workflow/rest/external/StageNodeExt.java
@@ -43,7 +43,7 @@ public class StageNodeExt extends FlowNodeExt {
     private List<AtomFlowNodeExt> stageFlowNodes;
 
     // Limit the size of child nodes returned
-    static final int MAX_CHILD_NODES = 100;
+    static final int MAX_CHILD_NODES = Integer.getInteger(StageNodeExt.class.getName()+".maxChildNodes", 100);
 
     @JsonInclude(JsonInclude.Include.NON_NULL)
     public List<AtomFlowNodeExt> getStageFlowNodes() {

--- a/ui/src/main/js/model/runs-stage-grouped.js
+++ b/ui/src/main/js/model/runs-stage-grouped.js
@@ -257,15 +257,10 @@ function addCompletionEstimates(timedObject, avgDurationMillis, averagedOver) {
 }
 
 function RunGroupGenerator(maxRuns) {
-    this.maxRuns = 10; // Default max of 5 runs per group... arbitrary :)
     this.stageData = [];
     this.runs = [];
 }
 RunGroupGenerator.prototype.addRun = function(run) {
-    if (this.runs.length >= this.maxRuns) {
-        return false;
-    }
-
     // Make sure the stage name ordering matches
     for (var i = 0; i < run.stages.length; i++) {
         var stage = run.stages[i];


### PR DESCRIPTION
Provides java system properties to configure the hardcoded limits on jobs per run, etc per [JENKINS-34791](https://issues.jenkins-ci.org/browse/JENKINS-34791).