### PR TITLE
Fix the gulp bundle phase so the adjunct is included

### DIFF
--- a/ui/pom.xml
+++ b/ui/pom.xml
@@ -111,6 +111,25 @@
             </resource>
         </resources>
         <plugins>
+            <!-- Workaround for failing to package the adjuncts with the plugin parent-pom until
+                on a version including https://github.com/jenkinsci/plugin-pom/pull/27 -->
+            <plugin>
+                <groupId>com.github.eirslett</groupId>
+                <artifactId>frontend-maven-plugin</artifactId>
+                <version>1.0</version>
+                <executions>
+                    <execution>
+                        <phase>generate-sources</phase>
+                        <id>gulp bundle</id>
+                        <goals>
+                            <goal>gulp</goal>
+                        </goals>
+                        <configuration>
+                            <arguments>bundle</arguments>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
             <plugin>
                 <groupId>com.github.klieber</groupId>
                 <artifactId>phantomjs-maven-plugin</artifactId>


### PR DESCRIPTION
Fixes the NoSuchAdjunctExceptions with plugin-pom 2.6+ until we can update to the latest plugin parent pom & validate against it.  

Fix to the plugin parent is in PR https://github.com/jenkinsci/plugin-pom/pull/27

@reviewbybees especially @jglick