### PR TITLE
Remove node labels until they can correctly evaluate blocks with new FlowScanner

### DIFF
--- a/ui/src/main/js/view/templates/pipeline-staged.hbs
+++ b/ui/src/main/js/view/templates/pipeline-staged.hbs
@@ -101,6 +101,7 @@
                         <div class="progress-bar progress-bar-striped" style="width: {{this.percentCompleteEstimate}}%"></div>
                     </div>
                 {{/if}}
+                {{!-- TODO add back node labels once we have block-aware pipeline graph analysis, per JENKINS-33290 --}}
                 {{!-- #if this.execNode}}
                     <span class="exec-node label label-info" title="executed on '{{this.execNode}}'">{{this.execNode}}</span>
                 {{/if --}}

--- a/ui/src/main/js/view/templates/pipeline-staged.hbs
+++ b/ui/src/main/js/view/templates/pipeline-staged.hbs
@@ -101,9 +101,9 @@
                         <div class="progress-bar progress-bar-striped" style="width: {{this.percentCompleteEstimate}}%"></div>
                     </div>
                 {{/if}}
-                {{#if this.execNode}}
+                {{!-- #if this.execNode}}
                     <span class="exec-node label label-info" title="executed on '{{this.execNode}}'">{{this.execNode}}</span>
-                {{/if}}
+                {{/if --}}
                 {{#if this.pauseDurationMillis}}
                     <div class="pause-duration">
                         <span title="paused for {{formatTime this.pauseDurationMillis 2}}">(paused for {{formatTime this.pauseDurationMillis 2}})</span>


### PR DESCRIPTION
Node label uses can't be correctly computed without a block-aware and parallel-aware analysis method. 

We are removing them temporarily per [JENKINS-33290](https://issues.jenkins-ci.org/browse/JENKINS-33290) until a flow analyzer based on the ForkScanner in https://github.com/jenkinsci/workflow-api-plugin/pull/2 and the block-aware analysis APIs in https://github.com/jenkinsci/workflow-api-plugin/pull/6
can be added to replace FlowNodeUtil.