### PR TITLE
Fix JENKINS-34644 by using timing info for run to work around rare issues sues with timing and FlowEndNode

### DIFF
--- a/rest-api/src/main/java/com/cloudbees/workflow/rest/external/RunExt.java
+++ b/rest-api/src/main/java/com/cloudbees/workflow/rest/external/RunExt.java
@@ -355,6 +355,14 @@ public class RunExt {
                 runExt.sortStages();
 
                 FlowNodeExt lastStage = runExt.getLastStage();
+
+                // Correct for rare cases with 0 for a FlowEndNode
+                if (lastStage.getPauseDurationMillis() < 0) {
+                    lastStage.setPauseDurationMillis(0);
+                }
+                if (lastStage.getDurationMillis() < 0) {
+                    lastStage.setDurationMillis(runExt.getEndTimeMillis()-lastStage.getStartTimeMillis());
+                }
                 lastStage.setStatus(runExt.getStatus());
             }
 


### PR DESCRIPTION
Workaround that solves [JENKINS-34644](https://issues.jenkins-ci.org/browse/JENKINS-34644) and tests the workaround.  

@reviewbybees 