### PR TITLE
Improve stageview status handling

### DIFF
--- a/rest-api/src/main/java/com/cloudbees/workflow/rest/external/StatusExt.java
+++ b/rest-api/src/main/java/com/cloudbees/workflow/rest/external/StatusExt.java
@@ -35,7 +35,8 @@ public enum StatusExt {
     SUCCESS,
     IN_PROGRESS,
     PAUSED_PENDING_INPUT,
-    FAILED;
+    FAILED,
+    UNSTABLE;  // Custom values
 
     public static StatusExt valueOf(ErrorAction errorAction) {
         if (errorAction == null) {

--- a/ui/src/main/js/view/templates/pipeline-staged.hbs
+++ b/ui/src/main/js/view/templates/pipeline-staged.hbs
@@ -88,6 +88,9 @@
                 {{#ifCond this.status '===' 'IN_PROGRESS'}}
                     <div cbwf-controller="stage-actions-popover" descUrl="{{this._links.self.href}}" notIf="stage-actions-popover,stage-failed-popover" caption="In Progress" />
                 {{/ifCond}}
+                {{#ifCond this.status '===' 'UNSTABLE'}}
+                    <div cbwf-controller="stage-actions-popover" descUrl="{{this._links.self.href}}" notIf="stage-actions-popover,stage-failed-popover" caption="Unstable Build" />
+                {{/ifCond}}
                 {{#ifCond this.status '===' 'PAUSED_PENDING_INPUT'}}
                     <div cbwf-controller="run-input-required" objectUrl="{{../../_links.nextPendingInputAction.href}}" />
                     <div class="status">paused</div>

--- a/ui/src/main/js/view/templates/pipeline-staged.less
+++ b/ui/src/main/js/view/templates/pipeline-staged.less
@@ -51,6 +51,12 @@
     td.SUCCESS .cell-color {
       background: rgba(0, 255, 0, .1)
     }
+    td.UNSTABLE .cell-color {
+      background: rgba(230, 230, 9, .2)
+    }
+    tr.UNSTABLE .cell-color {
+          background: rgba(230, 230, 9, .2)
+    }
     tr.FAILED .cell-color {
       background: rgba(255, 50, 0, .1)
     }


### PR DESCRIPTION
Addresses [JENKINS-33700](https://issues.jenkins-ci.org/browse/JENKINS-33700) by adding UNSTABLE status, and also solves [JENKINS-36523](https://issues.jenkins-ci.org/browse/JENKINS-36523) and [JENKINS-34212](https://issues.jenkins-ci.org/browse/JENKINS-34212).

That said, annotated stages are probably becoming a must-have. 

- [x] Basic implementation of UNSTABLE status and correct stage statuses based on overall run status
- [ ] Unit tests for a variety of runs with different stage combinations + UNSTABLE (and using currentBuild.result 