### PR TITLE
Fix handling of multiline strings for input box prompts [JENKINS-36661]

### DIFF
--- a/ui/src/main/js/view/templates/index.js
+++ b/ui/src/main/js/view/templates/index.js
@@ -63,6 +63,12 @@ function registerHBSHelper(name, helper) {
     handlebars.registerHelper(name, helper);
 }
 
+registerHBSHelper('breaklines', function(text) {
+    text = handlebars.escapeExpression(text);
+    text = text.replace(/(\r\n|\n|\r)/gm, '<br>');
+    return new handlebars.SafeString(text);
+});
+
 registerHBSHelper('dumpObj', function(object) {
     return JSON.stringify(object, undefined, 4);
 });

--- a/ui/src/main/js/view/templates/run-input-required.hbs
+++ b/ui/src/main/js/view/templates/run-input-required.hbs
@@ -1,6 +1,6 @@
 <div class="input cbwf-info-action-popover run-input-required">
     <div class="remove"><span class="glyphicon glyphicon-remove remove"></span></div>
-    <div class="caption">{{message}}</div>
+    <div class="caption">{{breaklines message}}</div>
     <div class="form">
         <div class="inputs">
             {{#each inputs}}


### PR DESCRIPTION
Easy fix that resolves [JENKINS-36661](https://issues.jenkins-ci.org/browse/JENKINS-36661).  We do escaping on the string and replace all end of line combinations with a \<br\> tag. 

@reviewbybees 