### PR TITLE
Fix  JENKINS-38133 and show timing

### DIFF
--- a/rest-api/src/main/java/com/cloudbees/workflow/rest/external/AtomFlowNodeExt.java
+++ b/rest-api/src/main/java/com/cloudbees/workflow/rest/external/AtomFlowNodeExt.java
@@ -26,6 +26,7 @@ package com.cloudbees.workflow.rest.external;
 import com.cloudbees.workflow.rest.endpoints.flownode.Log;
 import com.cloudbees.workflow.rest.hal.Link;
 import org.jenkinsci.plugins.workflow.actions.ErrorAction;
+import org.jenkinsci.plugins.workflow.actions.LogAction;
 import org.jenkinsci.plugins.workflow.graph.FlowNode;
 import org.kohsuke.stapler.Stapler;
 
@@ -53,7 +54,9 @@ public class AtomFlowNodeExt extends FlowNodeExt {
         AtomFlowNodeExt flowNodeExt = new AtomFlowNodeExt();
         flowNodeExt.addBasicNodeData(node);
         if (flowNodeExt.getStatus() != StatusExt.NOT_EXECUTED) {
-            flowNodeExt.get_links().setLog(Link.newLink(Log.getUrl(node)));
+            if (node.getAction(LogAction.class) != null) {
+                flowNodeExt.get_links().setLog(Link.newLink(Log.getUrl(node)));
+            }
         }
         flowNodeExt.addParentNodeRefs(node);
         return flowNodeExt;
@@ -66,7 +69,9 @@ public class AtomFlowNodeExt extends FlowNodeExt {
         // It would be super awesome if we didn't need to make a throwaway object
         basic.addBasicNodeData(node, execNodeName, duration, startTimeMillis, status, error);
         if (basic.getStatus() != StatusExt.NOT_EXECUTED && Stapler.getCurrentRequest() != null) {
-            basic.get_links().setLog(Link.newLink(Log.getUrl(node)));
+            if (node.getAction(LogAction.class) != null) {
+                basic.get_links().setLog(Link.newLink(Log.getUrl(node)));
+            }
         }
         basic.addParentNodeRefs(node);
         return basic;

--- a/ui/src/main/js/view/templates/stage-logs.hbs
+++ b/ui/src/main/js/view/templates/stage-logs.hbs
@@ -2,8 +2,14 @@
     {{#each stageFlowNodes}}
         {{#if this._links.log.href}}
         <div class="node-log-frame {{this.status}}" cbwf-controller="node-log" objectUrl="{{this._links.log.href}}">
-            <div class="node-name"><span class="glyphicon glyphicon-collapse-down" title="Expand"></span><span class="glyphicon glyphicon-collapse-up" title="Collapse"></span> {{this.name}}</div>
+            <div class="node-name"><span class="glyphicon glyphicon-collapse-down" title="Expand"></span><span class="glyphicon glyphicon-collapse-up" title="Collapse"></span>
+                {{this.name}}  {{#if this.durationMillis}}(self time {{formatTime this.durationMillis}}){{/if}}
+            </div>
             <div class="log-details"></div>
+        </div>
+        {{else}}
+        <div class="node-log-frame {{this.status}}" objectUrl="{{this._links.self.href}}">
+            <div class="node-name">{{this.name}}  {{#if this.durationMillis}}(self time {{formatTime this.durationMillis}}){{/if}}</div>
         </div>
         {{/if}}
     {{/each}}

--- a/ui/src/test/js/view/stage-logs-spec.js
+++ b/ui/src/test/js/view/stage-logs-spec.js
@@ -65,9 +65,7 @@ describe("view/stage-logs", function () {
             var nodeLogFrames = $('.node-log-frame');
 
             // TODO: hmmmm ... we may need to modify the test data model here ... see the comment below.
-            // There should only be 3 node log frames, even though there were 5 steps in the
-            // stage (see checkpoint_resumed_stage_description.json). That's because the first 2 steps
-            // were not executed because the run/build was a resumed from checkpoint build.
+            // There should only be 1 log frame per step (with ones not having logs omitting the step)
             expect(nodeLogFrames.size()).toBe(5);
 
             // Click on the first log

--- a/ui/src/test/js/view/stage-logs-spec.js
+++ b/ui/src/test/js/view/stage-logs-spec.js
@@ -68,7 +68,7 @@ describe("view/stage-logs", function () {
             // There should only be 3 node log frames, even though there were 5 steps in the
             // stage (see checkpoint_resumed_stage_description.json). That's because the first 2 steps
             // were not executed because the run/build was a resumed from checkpoint build.
-            expect(nodeLogFrames.size()).toBe(3);
+            expect(nodeLogFrames.size()).toBe(5);
 
             // Click on the first log
             var firstLogNode = $(nodeLogFrames.get(0));


### PR DESCRIPTION
Fixes [JENKINS-38133](https://issues.jenkins-ci.org/browse/JENKINS-38133) showing log expand options for steps with no logs, and also adds basic timing info to it.

<img width="727" alt="Screenshot" src="https://cloud.githubusercontent.com/assets/5400948/18437800/928d004e-78cc-11e6-971e-9c076e792e3d.png">
