### PR TITLE
Do not throw the stage view under the test trend graphs (Checkstyle, …

### DIFF
--- a/ui/src/main/less/stageview_adjunct.less
+++ b/ui/src/main/less/stageview_adjunct.less
@@ -1,6 +1,5 @@
 // The main container for CBWF Stage View
 .cbwf-stage-view {
-  clear: right;
   padding: 15px 0;
 }
 


### PR DESCRIPTION
…PMD, ...)


I'm using Jenkins 2.19.3 with the latest versions for pipelines and static analysis collector plugins. Starting with [1.49](https://wiki.jenkins-ci.org/display/JENKINS/Analysis+Collector+Plugin), the graphs are shown in the pipeline view, but because of that, the pipelines are under these graphs even if there is enough space.

Screenshot (Chrome 54.0.2840.99)
![image](https://cloud.githubusercontent.com/assets/5037739/20570356/f1843474-b1ab-11e6-9513-ddef57a17752.png)


Removing the "clear: right" seems to solve this issue with no side effects from my basic checks.

![image](https://cloud.githubusercontent.com/assets/5037739/20570432/3ccf55ee-b1ac-11e6-981c-f5aabf6b1582.png)


