### PR TITLE
Make build title link to the build itself

### DIFF
--- a/ui/src/main/js/view/templates/pipeline-staged.hbs
+++ b/ui/src/main/js/view/templates/pipeline-staged.hbs
@@ -43,7 +43,7 @@
         <td class="stage-start">
           <div class="cell-color">
             <div class="cell-box">
-              <div class="jobName"><span class="badge">{{this.name}}</span></div>
+              <div class="jobName"><span class="badge"><a href="{{this.id}}">{{this.name}}</a></span></div>
               <div class="stage-start-box">
                 <div class="stage-start-time">
                   <div class="date">{{formatDate this.startTimeMillis 'month'}} {{formatDate this.startTimeMillis 'dom'}}</div>

--- a/ui/src/main/js/view/templates/pipeline-staged.less
+++ b/ui/src/main/js/view/templates/pipeline-staged.less
@@ -397,6 +397,9 @@
     font-size: 11px;
     text-shadow: rgba(0, 0, 0, .5) 0 -1px 1px;
   }
+  .jobName .badge a {
+    color: inherit;
+  }
   .UNSTABLE .jobName .badge {
       background-color: #E2E203;
   }

--- a/ui/src/test/resources/view/pipeline_staged/render/03_rest_api_runs_checkpoint_rerun.html
+++ b/ui/src/test/resources/view/pipeline_staged/render/03_rest_api_runs_checkpoint_rerun.html
@@ -55,7 +55,7 @@
             <td class="stage-start">
               <div class="cell-color">
                 <div class="cell-box">
-                  <div class="jobName"><span class="badge">#2</span></div>
+                  <div class="jobName"><span class="badge"><a href="2">#2</a></span></div>
                   <div class="stage-start-box">
                     <div class="stage-start-time">
                       <div class="date">1414318300276 1414318300276</div>
@@ -114,7 +114,7 @@
             <td class="stage-start">
               <div class="cell-color">
                 <div class="cell-box">
-                  <div class="jobName"><span class="badge">#1</span></div>
+                  <div class="jobName"><span class="badge"><a href="1">#1</a></span></div>
                   <div class="stage-start-box">
                     <div class="stage-start-time">
                       <div class="date">1414318232950 1414318232950</div>

--- a/ui/src/test/resources/view/pipeline_staged/render/04_rest_api_runs_failed.html
+++ b/ui/src/test/resources/view/pipeline_staged/render/04_rest_api_runs_failed.html
@@ -55,7 +55,7 @@
         <td class="stage-start">
           <div class="cell-color">
             <div class="cell-box">
-              <div class="jobName"><span class="badge">#3</span></div>
+              <div class="jobName"><span class="badge"><a href="2014-10-26_10-12-29">#3</a></span></div>
               <div class="stage-start-box">
                 <div class="stage-start-time">
                   <div class="date">1414318349569 1414318349569</div>
@@ -121,7 +121,7 @@
         <td class="stage-start">
           <div class="cell-color">
             <div class="cell-box">
-              <div class="jobName"><span class="badge">#1</span></div>
+              <div class="jobName"><span class="badge"><a href="2014-10-26_10-10-32">#1</a></span></div>
               <div class="stage-start-box">
                 <div class="stage-start-time">
                   <div class="date">1414318232950 1414318232950</div>

--- a/ui/src/test/resources/view/pipeline_staged/render/07_rest_api_runs_in_progress.html
+++ b/ui/src/test/resources/view/pipeline_staged/render/07_rest_api_runs_in_progress.html
@@ -39,7 +39,7 @@
         <td class="stage-start">
           <div class="cell-color">
             <div class="cell-box">
-              <div class="jobName"><span class="badge">#1</span></div>
+              <div class="jobName"><span class="badge"><a href="2014-10-26_10-10-32">#1</a></span></div>
               <div class="stage-start-box">
                 <div class="stage-start-time">
                   <div class="date">1414318232950 1414318232950</div>

--- a/ui/src/test/resources/view/pipeline_staged/render/08_rest_api_unstable_run.html
+++ b/ui/src/test/resources/view/pipeline_staged/render/08_rest_api_unstable_run.html
@@ -39,7 +39,7 @@
         <td class="stage-start">
           <div class="cell-color">
             <div class="cell-box">
-              <div class="jobName"><span class="badge">#1</span></div>
+              <div class="jobName"><span class="badge"><a href="2014-10-26_10-10-32">#1</a></span></div>
               <div class="stage-start-box">
                 <div class="stage-start-time">
                   <div class="date">1414318232950 1414318232950</div>

--- a/ui/src/test/resources/view/pipeline_staged/render/expected.html
+++ b/ui/src/test/resources/view/pipeline_staged/render/expected.html
@@ -47,7 +47,7 @@
         <td class="stage-start">
           <div class="cell-color">
             <div class="cell-box">
-              <div class="jobName"><span class="badge">#3</span></div>
+              <div class="jobName"><span class="badge"><a href="">#3</a></span></div>
               <div class="stage-start-box">
                 <div class="stage-start-time">
                   <div class="date">1411556423000 1411556423000</div>
@@ -104,7 +104,7 @@
         <td class="stage-start">
           <div class="cell-color">
             <div class="cell-box">
-              <div class="jobName"><span class="badge">#2</span></div>
+              <div class="jobName"><span class="badge"><a href="">#2</a></span></div>
               <div class="stage-start-box">
                 <div class="stage-start-time">
                   <div class="date">1411556089000 1411556089000</div>
@@ -158,7 +158,7 @@
         <td class="stage-start">
           <div class="cell-color">
             <div class="cell-box">
-              <div class="jobName"><span class="badge">#1</span></div>
+              <div class="jobName"><span class="badge"><a href="">#1</a></span></div>
               <div class="stage-start-box">
                 <div class="stage-start-time">
                   <div class="date">1411552553000 1411552553000</div>


### PR DESCRIPTION
Currently, to view a particular build from the pipeline view, you have to find the corresponding job in the build list. To make things more convenient, make the build title link to the build itself, just as each build is in the build list. 
Here is an example how it looks like: 
![](http://i.imgur.com/7fe0OU8.png)