### PR TITLE
Fix build broken by changes to node use in new parent pom

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -8,6 +8,10 @@
     "moment": "~2.8.3",
     "window-handle": "^1.0.0"
   },
+  "scripts": {
+    "mvnbuild": "gulp bundle",
+    "mvntest": "gulp test"
+  },
   "devDependencies": {
     "gulp": "^3.9.0",
     "gulp-util": "^3.0.7",

--- a/ui/pom.xml
+++ b/ui/pom.xml
@@ -75,12 +75,6 @@
             <version>1.18</version>
             <scope>test</scope>
         </dependency>
-        <!--<dependency>
-            <groupId>org.jenkins-ci.plugins.workflow</groupId>
-            <artifactId>workflow-api</artifactId>
-            <version>2.0</version>
-            <scope>test</scope>
-        </dependency>-->
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-support</artifactId>
@@ -127,25 +121,6 @@
             </resource>
         </resources>
         <plugins>
-            <!-- Workaround for failing to package the adjuncts with the plugin parent-pom until
-                on a version including https://github.com/jenkinsci/plugin-pom/pull/27 -->
-            <plugin>
-                <groupId>com.github.eirslett</groupId>
-                <artifactId>frontend-maven-plugin</artifactId>
-                <version>1.0</version>
-                <executions>
-                    <execution>
-                        <phase>generate-sources</phase>
-                        <id>gulp bundle</id>
-                        <goals>
-                            <goal>gulp</goal>
-                        </goals>
-                        <configuration>
-                            <arguments>bundle</arguments>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
             <plugin>
                 <groupId>com.github.klieber</groupId>
                 <artifactId>phantomjs-maven-plugin</artifactId>


### PR DESCRIPTION
Similarly to https://github.com/jenkinsci/pipeline-stage-view-plugin/pull/37/files#r118344817 so see https://github.com/jenkinsci/workflow-cps-plugin/pull/87

Thanks to @jglick  for pointing me at the culprit for the latest failure.

It's possible that some of the frontend plugin dependencies might be removable -- will tinker with that. 

Manually tested to ensure it will still work for users in the wild, not just testing & HPI:run (which handle adjuncts a bit differently). 