### PR TITLE
Fix broken caching handling of job renames by purging cache entry [JENKINS-38159]

### DIFF
--- a/rest-api/src/test/java/com/cloudbees/workflow/flownode/CachingTest.java
+++ b/rest-api/src/test/java/com/cloudbees/workflow/flownode/CachingTest.java
@@ -103,8 +103,8 @@ public class CachingTest {
         // Check we still have the jobs cached appropriately
         job.renameTo("NewName");
         String newJobKey = build.getExternalizableId();
-        Assert.assertNull("Cache should be moved for renamed job", cache.getIfPresent(runKey));
+        Assert.assertNull("Cache entry should be removed for renamed job", cache.getIfPresent(runKey));
         Assert.assertEquals("Non-renamed jobs should still be cached", r2, cache.getIfPresent(runKey2));
-        Assert.assertEquals("Moved cached entry should be present after rename", r, cache.getIfPresent(newJobKey));
+        Assert.assertNull("Cache entry should not be present with new job name", cache.getIfPresent(newJobKey));
     }
 }


### PR DESCRIPTION
[JENKINS-38159](https://issues.jenkins-ci.org/browse/JENKINS-38159) - log URLs would have to be rewritten (as well as all HAL links in JSON), so it's better to just purge the cache entry and rebuild when needed. 