### PR TITLE
Fix run timing bug for runs [JENKINS-40162]

### DIFF
--- a/rest-api/src/main/java/com/cloudbees/workflow/flownode/FlowNodeUtil.java
+++ b/rest-api/src/main/java/com/cloudbees/workflow/flownode/FlowNodeUtil.java
@@ -56,17 +56,12 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import java.util.Set;
 import java.util.concurrent.ConcurrentMap;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 /**
  * @author <a href="mailto:tom.fennelly@gmail.com">tom.fennelly@gmail.com</a>
  */
 public class FlowNodeUtil {
-
-    private static final Logger LOGGER = Logger.getLogger(FlowNodeUtil.class.getName());
 
     private FlowNodeUtil() {
     }

--- a/rest-api/src/main/java/com/cloudbees/workflow/rest/endpoints/JobAPI.java
+++ b/rest-api/src/main/java/com/cloudbees/workflow/rest/endpoints/JobAPI.java
@@ -29,12 +29,9 @@ import com.cloudbees.workflow.rest.external.RunExt;
 import com.cloudbees.workflow.util.ModelUtil;
 import com.cloudbees.workflow.util.ServeJson;
 import hudson.Extension;
-import hudson.model.Fingerprint;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
-import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 import org.kohsuke.stapler.QueryParameter;
 
-import javax.annotation.CheckForNull;
 import java.util.List;
 
 /**

--- a/rest-api/src/main/java/com/cloudbees/workflow/rest/endpoints/flownode/Describe.java
+++ b/rest-api/src/main/java/com/cloudbees/workflow/rest/endpoints/flownode/Describe.java
@@ -24,13 +24,11 @@
 package com.cloudbees.workflow.rest.endpoints.flownode;
 
 import com.cloudbees.workflow.rest.external.AtomFlowNodeExt;
-import com.cloudbees.workflow.rest.external.ChunkVisitor;
 import com.cloudbees.workflow.rest.external.FlowNodeExt;
 import com.cloudbees.workflow.rest.external.RunExt;
 import com.cloudbees.workflow.rest.external.StageNodeExt;
 import com.cloudbees.workflow.rest.endpoints.FlowNodeAPI;
 import hudson.model.Queue;
-import org.jenkinsci.plugins.workflow.flow.FlowExecution;
 import org.jenkinsci.plugins.workflow.graph.AtomNode;
 import org.jenkinsci.plugins.workflow.graph.FlowNode;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;

--- a/rest-api/src/main/java/com/cloudbees/workflow/rest/hal/Link.java
+++ b/rest-api/src/main/java/com/cloudbees/workflow/rest/hal/Link.java
@@ -23,7 +23,6 @@
  */
 package com.cloudbees.workflow.rest.hal;
 
-import com.cloudbees.workflow.util.ModelUtil;
 
 /**
  * HAL <a href="https://tools.ietf.org/html/draft-kelly-json-hal-06#section-5">link</a>

--- a/rest-api/src/main/java/com/cloudbees/workflow/rest/hal/Links.java
+++ b/rest-api/src/main/java/com/cloudbees/workflow/rest/hal/Links.java
@@ -23,7 +23,6 @@
  */
 package com.cloudbees.workflow.rest.hal;
 
-import com.cloudbees.workflow.util.ModelUtil;
 
 /**
  * Abstract HAL <a href="https://tools.ietf.org/html/draft-kelly-json-hal-06#section-4.1.1">_links</a>

--- a/rest-api/src/test/java/com/cloudbees/workflow/rest/endpoints/UndefinedWorkflowTest.java
+++ b/rest-api/src/test/java/com/cloudbees/workflow/rest/endpoints/UndefinedWorkflowTest.java
@@ -43,7 +43,7 @@ public class UndefinedWorkflowTest {
     public JenkinsRule jenkinsRule = new JenkinsRule();
 
     @Test
-    public void test_success_flow() throws Exception {
+    public void testUndefinedRun() throws Exception {
         WorkflowJob job = jenkinsRule.jenkins.createProject(WorkflowJob.class, "Noddy Job");
 
         // Purposely not setting a workflow definition on the job
@@ -65,8 +65,8 @@ public class UndefinedWorkflowTest {
 
     private void assertRunOkay(RunExt workflowRun) {
         Assert.assertEquals(0, workflowRun.getStages().size());
-        Assert.assertEquals(0L, workflowRun.getEndTimeMillis());
+        Assert.assertTrue("Run that should be near instant wasn't", workflowRun.getDurationMillis() < 100);
         Assert.assertEquals(0L, workflowRun.getPauseDurationMillis());
-        Assert.assertEquals(0L, workflowRun.getQueueDurationMillis());
+        Assert.assertTrue("Run reports excessive queuing time", workflowRun.getQueueDurationMillis() < 100);
     }
 }


### PR DESCRIPTION
Also incidentally fix computation of queue durations (legacy logic was not using run startTime/timestamp like it should, apparently un-noticed because the difference is small).

Run duration (as separate from stage) was not getting the end time directly from the run like it ought to. 

[JENKINS-40162](https://issues.jenkins-ci.org/browse/JENKINS-40162).