### PR TITLE
[JENKINS-44636] Verifying stage view works with updated dependencies.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>2.22</version>
+        <version>2.31</version>
     </parent>
 
     <groupId>org.jenkins-ci.plugins.pipeline-stage-view</groupId>

--- a/rest-api/pom.xml
+++ b/rest-api/pom.xml
@@ -48,12 +48,12 @@
             <!-- Temporary version due to upstream dependency, just until that is released -->
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-api</artifactId>
-            <version>2.15</version>
+            <version>2.19-20170703.153905-1</version> <!-- TODO: update to release once https://github.com/jenkinsci/workflow-api-plugin/pull/42 is merged and released -->
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>pipeline-graph-analysis</artifactId>
-            <version>1.1</version>
+            <version>1.5-20170703.154511-4</version> <!-- TODO: update to release when https://github.com/jenkinsci/pipeline-graph-analysis-plugin/pull/11 is merged and released -->
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
@@ -80,7 +80,7 @@
             <!-- Temporary version due to upstream dependency, just until that is released -->
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-cps</artifactId>
-            <version>2.31</version>
+            <version>2.37-20170628.162114-1</version> <!-- TODO: update to 2.37 when released for https://github.com/jenkinsci/workflow-cps-plugin/commit/cabca496e481f0800f45a708533ffccc88a62ec4 -->
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -92,7 +92,19 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-durable-task-step</artifactId>
-            <version>2.0</version>
+            <version>2.13-20170703.154226-4</version> <!-- TODO: Switch to release once https://github.com/jenkinsci/workflow-durable-task-step-plugin/pull/42 is merged and released -->
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>scm-api</artifactId>
+            <version>2.0.8</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins.workflow</groupId>
+            <artifactId>workflow-scm-step</artifactId>
+            <version>2.4</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/rest-api/src/main/java/com/cloudbees/workflow/rest/endpoints/RunAPI.java
+++ b/rest-api/src/main/java/com/cloudbees/workflow/rest/endpoints/RunAPI.java
@@ -39,6 +39,7 @@ import org.jenkinsci.plugins.workflow.support.steps.input.InputAction;
 import org.jenkinsci.plugins.workflow.support.steps.input.InputStepExecution;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.DoNotUse;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.Stapler;
 import org.kohsuke.stapler.interceptor.RequirePOST;
@@ -96,7 +97,7 @@ public class RunAPI extends AbstractWorkflowRunActionHandler {
         return doDescribe();
     }
 
-    @Restricted(DoNotUse.class) // WebMethod
+    @Restricted(NoExternalUse.class) // WebMethod
     @ServeJson
     public RunExt doDescribe() {
         return RunExt.create(getRun()).createWrapper();

--- a/ui/pom.xml
+++ b/ui/pom.xml
@@ -72,7 +72,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>script-security</artifactId>
-            <version>1.18</version>
+            <version>1.26</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -84,7 +84,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-scm-step</artifactId>
-            <version>2.1</version>
+            <version>2.4</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
[JENKINS-44636](https://issues.jenkins-ci.org/browse/JENKINS-44636)

Just wanted to be sure we didn't break something in Stage View with the JENKINS-44636 fixes. Doesn't actually do anything with the `QUEUED` state, just makes sure nothing breaks. =)

Downstream of https://github.com/jenkinsci/workflow-durable-task-step-plugin/pull/42, https://github.com/jenkinsci/workflow-api-plugin/pull/42, and https://github.com/jenkinsci/pipeline-graph-analysis-plugin/pull/11

cc @reviewbybees esp @svanoort 