### PR TITLE
Display empty stages with another color and status

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,1 @@
+buildPlugin()

--- a/rest-api/src/main/java/com/cloudbees/workflow/rest/external/ChunkVisitor.java
+++ b/rest-api/src/main/java/com/cloudbees/workflow/rest/external/ChunkVisitor.java
@@ -83,18 +83,22 @@ public class ChunkVisitor extends StandardChunkVisitor {
         }
         ExecDuration dur = (times == null) ? new ExecDuration() : new ExecDuration(times);
 
-        GenericStatus status;
+        StatusExt status;
         long startTime = 0;
         if (firstExecuted == null) {
-            status = GenericStatus.NOT_EXECUTED;
+            status = StatusExt.fromGenericStatus(GenericStatus.NOT_EXECUTED);
         } else {
-            status = StatusAndTiming.computeChunkStatus(run, chunk.getNodeBefore(), firstExecuted, chunk.getLastNode(), chunk.getNodeAfter());
+            if (stageNodeIds.size() != 0) {
+                status = StatusExt.fromGenericStatus(StatusAndTiming.computeChunkStatus(run, chunk.getNodeBefore(), firstExecuted, chunk.getLastNode(), chunk.getNodeAfter()));
+            } else {
+                status = StatusExt.EMPTY;
+            }
             startTime = TimingAction.getStartTime(firstExecuted);
         }
 
         // TODO add and use pipeline graph analysis API to allow us to get most of the metadata for the chunk in 1 pass, efficiently
         //  and only store the FlowNodes -- not the materialized objects.
-        stageExt.addBasicNodeData(chunk.getFirstNode(), "", dur, startTime, StatusExt.fromGenericStatus(status), chunk.getLastNode().getError());
+        stageExt.addBasicNodeData(chunk.getFirstNode(), "", dur, startTime, status, chunk.getLastNode().getError());
 
         int childNodeLength = Math.min(StageNodeExt.MAX_CHILD_NODES, stageContents.size());
         ArrayList<AtomFlowNodeExt> internals = new ArrayList<AtomFlowNodeExt>(childNodeLength);

--- a/rest-api/src/main/java/com/cloudbees/workflow/rest/external/StatusExt.java
+++ b/rest-api/src/main/java/com/cloudbees/workflow/rest/external/StatusExt.java
@@ -40,7 +40,8 @@ public enum StatusExt {
     IN_PROGRESS,
     PAUSED_PENDING_INPUT,
     FAILED,
-    UNSTABLE;  // Custom values
+    UNSTABLE,  // Custom values
+    EMPTY;
 
     public static StatusExt valueOf(ErrorAction errorAction) {
         if (errorAction == null) {

--- a/ui/src/main/js/model/rest-api.js
+++ b/ui/src/main/js/model/rest-api.js
@@ -32,7 +32,7 @@ var cache = {};
 
 function addCacheEntry (key, ob) {
     if (typeof ob === 'object') {
-        if (ob.status && (ob.status === 'SUCCESS' || ob.status === 'ABORTED' || ob.status === 'FAILED' || ob.status === 'UNSTABLE')) {
+        if (ob.status && (ob.status === 'SUCCESS' || ob.status === 'ABORTED' || ob.status === 'FAILED' || ob.status === 'UNSTABLE' || ob.status === 'EMPTY')) {
             cache[key] = ob;
         }
     }

--- a/ui/src/main/js/view/templates/pipeline-staged.hbs
+++ b/ui/src/main/js/view/templates/pipeline-staged.hbs
@@ -91,6 +91,9 @@
                 {{#ifCond this.status '===' 'UNSTABLE'}}
                     <div cbwf-controller="stage-actions-popover" descUrl="{{this._links.self.href}}" notIf="stage-actions-popover,stage-failed-popover" caption="Unstable Build" />
                 {{/ifCond}}
+                {{#ifCond this.status '===' 'EMPTY'}}
+                    <div cbwf-controller="stage-actions-popover" descUrl="{{this._links.self.href}}" notIf="stage-actions-popover,stage-failed-popover" caption="Empty" />
+                {{/ifCond}}
                 {{#ifCond this.status '===' 'PAUSED_PENDING_INPUT'}}
                     <div cbwf-controller="run-input-required" objectUrl="{{../../_links.nextPendingInputAction.href}}" />
                     <div class="status">paused</div>

--- a/ui/src/main/js/view/templates/pipeline-staged.hbs
+++ b/ui/src/main/js/view/templates/pipeline-staged.hbs
@@ -93,6 +93,7 @@
                 {{/ifCond}}
                 {{#ifCond this.status '===' 'EMPTY'}}
                     <div cbwf-controller="stage-actions-popover" descUrl="{{this._links.self.href}}" notIf="stage-actions-popover,stage-failed-popover" caption="Empty" />
+                    <div class="status">empty</div>
                 {{/ifCond}}
                 {{#ifCond this.status '===' 'PAUSED_PENDING_INPUT'}}
                     <div cbwf-controller="run-input-required" objectUrl="{{../../_links.nextPendingInputAction.href}}" />

--- a/ui/src/main/js/view/templates/pipeline-staged.less
+++ b/ui/src/main/js/view/templates/pipeline-staged.less
@@ -57,6 +57,9 @@
     tr.UNSTABLE .cell-color {
           background: rgba(230, 230, 9, .2)
     }
+    td.EMPTY .cell-color {
+      background: rgba(128, 128, 128, .1)
+    }
     tr.FAILED .cell-color {
       background: rgba(255, 50, 0, .1)
     }


### PR DESCRIPTION
When using declarative pipelines, skipped stages from a "when" clause are
displayed as "SUCCESS" in green. This is a bit misunderstanding because
you can think the stage was effectively ran.

With this commit, skipped stages are displayed in gray and have the
"EMPTY" status.