### PR TITLE
JobAndRunAPITest: Unit Test do not work on Windows - fix

### DIFF
--- a/rest-api/src/test/java/com/cloudbees/workflow/rest/endpoints/JobAndRunAPITest.java
+++ b/rest-api/src/test/java/com/cloudbees/workflow/rest/endpoints/JobAndRunAPITest.java
@@ -192,11 +192,11 @@ public class JobAndRunAPITest {
                 "echo 'hello guys'\n" +
                 "stage 'one'\n" +
                 "node {\n" +
-                "    sh 'sleep 5'\n" +
+                "    echo 'one'\n" +
                 "}\n" +
                 "stage 'two'\n" +
                 "node {\n" +
-                "    sh 'sleep 5'\n" +
+                "    echo 'two'\n" +
                 "}\n" +
                 "stage 'three'\n" +
                 "echo 'we are going to crash....'\n" +


### PR DESCRIPTION
Test testDuration0EdgeCase in JobAndRunAPITest use Jenkinsfile with "sh" tags. Those tags do not work (out of the box) on Windows. More over looks like there is no need to use "sh". I changed it to "echo".