### PR TITLE
Fix Url Generation Bug With '/' Suffix

### DIFF
--- a/rest-api/src/main/java/com/cloudbees/workflow/util/ModelUtil.java
+++ b/rest-api/src/main/java/com/cloudbees/workflow/util/ModelUtil.java
@@ -51,7 +51,7 @@ public class ModelUtil {
         if (!itemUrl.endsWith("/")) {
             itemUrl += "/";
         }
-        return rootUrl + "/" + itemUrl;
+        return (rootUrl.endsWith("/")) ? rootUrl+itemUrl : rootUrl + "/" + itemUrl;
     }
 
     public static String getRootUrl() {


### PR DESCRIPTION
Users have noted occasional issues with bogus URLS -- a bogus '/' was being inserted into relative URLs, resulting in '//some/path' which becomes 'https://some/path' rather than 'https://urlBase/some/path'. 

Unfortunately it was not consistently reproducible, so this best-guess change was cut as a hotfix for them to try... and it proves to have resolved the issue. 

The string "CD-418" may be meaningful to some.