### PR TITLE
Avoid generating NaNy NaNd

### DIFF
--- a/ui/src/main/js/util/formatters.js
+++ b/ui/src/main/js/util/formatters.js
@@ -48,7 +48,7 @@ exports.memory = function (amount) {
 }
 
 exports.time = function (millis, numUnitsToShow) {
-    if (millis <= 0) {
+    if (millis <= 0 || Number.isNaN(millis)) {
         return '0ms';
     }
 


### PR DESCRIPTION
We have a stage which doesn't happen...


Declarative: Checkout SCM | SCM clean up (avoid conflicts) | npm install | npm test | npm publish | Results | clean up
-- | -- | -- | -- | -- | -- | --
| 3s | NaNy NaNd | 30s | 40s | 1min 23s | 1s | 2s

It's been like this for a long time, the `NaNy NaNd` is pretty ugly.