### PR TITLE
Link to full node log from the window

### DIFF
--- a/rest-api/src/main/java/com/cloudbees/workflow/rest/endpoints/RunAPI.java
+++ b/rest-api/src/main/java/com/cloudbees/workflow/rest/endpoints/RunAPI.java
@@ -39,6 +39,7 @@ import org.jenkinsci.plugins.workflow.support.steps.input.InputAction;
 import org.jenkinsci.plugins.workflow.support.steps.input.InputStepExecution;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.DoNotUse;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.Stapler;
 import org.kohsuke.stapler.interceptor.RequirePOST;
@@ -96,7 +97,7 @@ public class RunAPI extends AbstractWorkflowRunActionHandler {
         return doDescribe();
     }
 
-    @Restricted(DoNotUse.class) // WebMethod
+    @Restricted(NoExternalUse.class) // WebMethod
     @ServeJson
     public RunExt doDescribe() {
         return RunExt.create(getRun()).createWrapper();

--- a/rest-api/src/main/java/com/cloudbees/workflow/rest/external/AtomFlowNodeExt.java
+++ b/rest-api/src/main/java/com/cloudbees/workflow/rest/external/AtomFlowNodeExt.java
@@ -25,6 +25,7 @@ package com.cloudbees.workflow.rest.external;
 
 import com.cloudbees.workflow.rest.endpoints.flownode.Log;
 import com.cloudbees.workflow.rest.hal.Link;
+import com.cloudbees.workflow.util.ModelUtil;
 import org.jenkinsci.plugins.workflow.actions.ErrorAction;
 import org.jenkinsci.plugins.workflow.actions.LogAction;
 import org.jenkinsci.plugins.workflow.graph.FlowNode;
@@ -69,8 +70,10 @@ public class AtomFlowNodeExt extends FlowNodeExt {
         // It would be super awesome if we didn't need to make a throwaway object
         basic.addBasicNodeData(node, execNodeName, duration, startTimeMillis, status, error);
         if (basic.getStatus() != StatusExt.NOT_EXECUTED && Stapler.getCurrentRequest() != null) {
-            if (node.getAction(LogAction.class) != null) {
+            LogAction la = node.getAction(LogAction.class);
+            if (la != null) {
                 basic.get_links().setLog(Link.newLink(Log.getUrl(node)));
+                basic.get_links().setConsole(Link.newLink(ModelUtil.getFullItemUrl(node) + la.getUrlName()));
             }
         }
         basic.addParentNodeRefs(node);

--- a/rest-api/src/main/java/com/cloudbees/workflow/rest/external/FlowNodeExt.java
+++ b/rest-api/src/main/java/com/cloudbees/workflow/rest/external/FlowNodeExt.java
@@ -143,7 +143,10 @@ public class FlowNodeExt {
     }
 
     public static final class FlowNodeLinks extends Links {
+        /** Link to rest API for the console */
         private Link log;
+        /** Link to the human consumable console page */
+        private Link console;
 
         @JsonInclude(JsonInclude.Include.NON_NULL)
         public Link getLog() {
@@ -152,6 +155,15 @@ public class FlowNodeExt {
 
         public void setLog(Link log) {
             this.log = log;
+        }
+
+        @JsonInclude(JsonInclude.Include.NON_NULL)
+        public Link getConsole() {
+            return console;
+        }
+
+        public void setConsole(Link console) {
+            this.console = console;
         }
     }
 

--- a/rest-api/src/test/java/com/cloudbees/workflow/rest/endpoints/FlowNodeAPITest.java
+++ b/rest-api/src/test/java/com/cloudbees/workflow/rest/endpoints/FlowNodeAPITest.java
@@ -25,6 +25,7 @@ package com.cloudbees.workflow.rest.endpoints;
 
 import com.cloudbees.workflow.Util;
 import com.cloudbees.workflow.rest.external.AtomFlowNodeExt;
+import com.cloudbees.workflow.rest.external.FlowNodeExt;
 import com.cloudbees.workflow.rest.external.FlowNodeLogExt;
 import com.cloudbees.workflow.rest.external.RunExt;
 import com.cloudbees.workflow.rest.external.StageNodeExt;
@@ -133,8 +134,10 @@ public class FlowNodeAPITest {
         jsonResponse = stageDescription.getWebResponse().getContentAsString();
         StageNodeExt stageDesc = jsonReadWrite.fromString(jsonResponse, StageNodeExt.class);
 
-        String logUrl = stageDesc.getStageFlowNodes().get(0).get_links().getLog().href;
+        FlowNodeExt.FlowNodeLinks links = stageDesc.getStageFlowNodes().get(0).get_links();
+        String logUrl = links.getLog().href;
         Assert.assertEquals("/jenkins/job/Noddy%20Job/1/execution/node/6/wfapi/log", logUrl);
+        Assert.assertEquals("/jenkins/job/Noddy%20Job/1/execution/node/6/log", links.getConsole().href);
 
         Page nodeLog = webClient.goTo(Util.removeRootUrl(logUrl), "application/json");
         jsonResponse = nodeLog.getWebResponse().getContentAsString();

--- a/ui/src/main/js/view/templates/stage-logs.hbs
+++ b/ui/src/main/js/view/templates/stage-logs.hbs
@@ -4,11 +4,14 @@
         {{#if this._links.log.href}}
         <div class="node-log-frame {{this.status}}" cbwf-controller="node-log" objectUrl="{{this._links.log.href}}">
             <div class="node-name"><span class="glyphicon glyphicon-collapse-down" title="Expand"></span><span class="glyphicon glyphicon-collapse-up" title="Collapse"></span>
+                <a class="log-link" href="{{this._links.console.href}}">
                 {{this.name}}
                 {{#if this.parameterDescription}}
-                    -- {{this.parameterDescription}} --
+                    -- {{this.parameterDescription}}
                 {{/if}}
+                </a>
                 {{#if this.durationMillis}} (self time {{formatTime this.durationMillis}}){{/if}}
+
             </div>
             <div class="log-details"></div>
         </div>


### PR DESCRIPTION
Switching from the convenient log thing to full log listing is annoying, and in case the logs are longish, often necessary. This adds direct link.

![psw-link](https://user-images.githubusercontent.com/206841/46480967-92943680-c7f2-11e8-9c41-24d79d0afc49.jpg)