### PR TITLE
Improve usability of the download artefacts popup 

### DIFF
--- a/ui/src/main/js/view/templates/pipeline-staged.less
+++ b/ui/src/main/js/view/templates/pipeline-staged.less
@@ -187,11 +187,16 @@
           overflow:hidden;
 
           .stage-end-icons {
+            height: 100%;
             width: 8em;
             position: absolute;
             top: 0;
             left: 10em;
             border: 1px solid transparent;
+            
+          .build-artifacts-popup {
+            height: inherit;
+          }
 
             .link {
               display: block;

--- a/ui/src/main/js/view/widgets/popover/style.less
+++ b/ui/src/main/js/view/widgets/popover/style.less
@@ -3,16 +3,14 @@
   z-index: 1000;
   border-radius: @cbwf-border-radius;
 
-  .alert{
+  .alert {
     box-shadow:0 3px 10px rgba(0,0,0,.25);
     text-shadow:#fff 0 0 2px, #fff 0 1px 1px;
-    max-width:25em;
+    max-width:80em;
   }
 }
-.cbwf-popover.placement-left{ 
-    
+.cbwf-popover.placement-left { 
     .alert:before{
         .top-right-caret;
-
-}
+    }
 }


### PR DESCRIPTION
For moderately long artefact names the popup takes up too much vertical space. To me it makes sense to try and keep longer names on one line. I've also increased the area of the button (no visual change) so the popup is less likely to disappear when a user tries to mouse over it.

This should prevent the list looking like this:
![image](https://user-images.githubusercontent.com/5424257/48453123-0ad81980-e7ed-11e8-9c55-75f02313ddba.png)

And make it look like this:
![image](https://user-images.githubusercontent.com/5424257/48453933-5a6c1480-e7f0-11e8-84e8-3bfb9a164385.png)
