### PR TITLE
[JENKINS-51490] Caption for Abort Button

### DIFF
--- a/rest-api/src/main/java/com/cloudbees/workflow/rest/external/PendingInputActionsExt.java
+++ b/rest-api/src/main/java/com/cloudbees/workflow/rest/external/PendingInputActionsExt.java
@@ -43,6 +43,7 @@ public class PendingInputActionsExt {
     private String id;
     @JsonInclude(JsonInclude.Include.NON_NULL)
     private String proceedText;
+    private String abortText;
     private String message;
     private List<InputParameterDefExt> inputs;
     private String proceedUrl; // Not a rest endpoint YET, so not including in _links
@@ -62,9 +63,11 @@ public class PendingInputActionsExt {
         return proceedText;
     }
 
-    public void setProceedText(String proceedText) {
-        this.proceedText = proceedText;
-    }
+    public void setProceedText(String proceedText) { this.proceedText = proceedText; }
+
+    public String getAbortText() { return abortText; }
+
+    public void setAbortText(String abortText) { this.abortText = abortText; }
 
     public String getMessage() {
         return message;
@@ -111,6 +114,7 @@ public class PendingInputActionsExt {
         String inputId = inputStepExecution.getId();
         inputActionExt.setId(inputId);
         inputActionExt.setProceedText(inputStepExecution.getInput().getOk());
+        inputActionExt.setAbortText(inputStepExecution.getInput().getAbort());
         inputActionExt.setMessage(inputStepExecution.getInput().getMessage());
 
         String runUrl = ModelUtil.getFullItemUrl(run.getUrl());

--- a/ui/src/main/js/view/templates/run-input-required.hbs
+++ b/ui/src/main/js/view/templates/run-input-required.hbs
@@ -53,7 +53,7 @@
         </div>
         <div class="buttons">
             <button type="submit" class="btn btn-primary btn-sm proceed-button">{{proceedText}}</button>
-            <button type="submit" class="btn btn-default btn-sm abort-button">Abort</button>
+            <button type="submit" class="btn btn-default btn-sm abort-button">{{abortText}}</button>
         </div>
     </div>
 

--- a/ui/src/test/resources/view/run_input_required/input-model-01.json
+++ b/ui/src/test/resources/view/run_input_required/input-model-01.json
@@ -1,6 +1,7 @@
 {
   "id": "Run-test-suites",
   "proceedText": "Okay",
+  "abortText": "Abort",
   "message": "Workflow Configuration",
   "inputs": [
     {

--- a/ui/src/test/resources/view/run_input_required/input-model-02.json
+++ b/ui/src/test/resources/view/run_input_required/input-model-02.json
@@ -1,6 +1,7 @@
 {
   "id": "Run-test-suites",
   "proceedText": "Okay",
+  "abortText": "Abort",
   "message": "Workflow Configuration",
   "inputs": [
     {


### PR DESCRIPTION
For ticket [JENKINS-51490](https://issues.jenkins-ci.org/browse/JENKINS-51490)

I have replicated the work done to caption the Ok button for the abort button.

This is a something that I often see requested.

Please let me know if there is anything I have missed, or if i need to write a test. I noticed there was no test for the Ok button, so also followed that path.

I currently have a PR in place for the input step plugin to support this logic here: https://github.com/jenkinsci/pipeline-input-step-plugin/pull/32