### PR TITLE
 Fix overlap when used with Test Result Trend

### DIFF
--- a/ui/src/main/less/stageview_adjunct.less
+++ b/ui/src/main/less/stageview_adjunct.less
@@ -1,6 +1,7 @@
 // The main container for CBWF Stage View
 .cbwf-stage-view {
   padding: 15px 0;
+  clear: right;
 }
 
 // Selectively import some twitter bootstrap styles.  Namespace them too.


### PR DESCRIPTION
Without clear, the pipeline stage-view overlaps the Test Result Trend graph that is floated to the right.