### PR TITLE
use standard isNaN function

### DIFF
--- a/ui/src/main/js/util/formatters.js
+++ b/ui/src/main/js/util/formatters.js
@@ -48,7 +48,7 @@ exports.memory = function (amount) {
 }
 
 exports.time = function (millis, numUnitsToShow) {
-    if (millis <= 0 || Number.isNaN(millis)) {
+    if (millis <= 0 || isNaN(millis)) {
         return '0ms';
     }
 


### PR DESCRIPTION
Number.isNaN() defined in ECMAScript 2015 (6th Edition, ECMA-262), that is not supported by IE11.
To provide compatibility, we have to use isNaN function

https://www.w3schools.com/js/js_versions.asp
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/isNaN#Specifications