### PR TITLE
Consistently use sandbox for CpsFlowDefinitions

### DIFF
--- a/rest-api/src/test/java/com/cloudbees/workflow/flownode/CachingTest.java
+++ b/rest-api/src/test/java/com/cloudbees/workflow/flownode/CachingTest.java
@@ -49,8 +49,8 @@ public class CachingTest {
         WorkflowJob job = jenkinsRule.jenkins.createProject(WorkflowJob.class, "BlinkinJob");
         job.setDefinition(new CpsFlowDefinition("" +
                 "stage 'first' \n" +
-                "echo 'done' "
-        ));
+                "echo 'done' ",
+                true));
         WorkflowRun build = jenkinsRule.assertBuildStatusSuccess(job.scheduleBuild2(0));
         RunExt r = RunExt.create(build);
         String runKey = build.getExternalizableId();
@@ -60,8 +60,8 @@ public class CachingTest {
         WorkflowJob job2 = jenkinsRule.jenkins.createProject(WorkflowJob.class, "StableJob");
         job2.setDefinition(new CpsFlowDefinition("" +
                 "stage 'second' \n" +
-                "echo 'done' "
-        ));
+                "echo 'done' ",
+                true));
         WorkflowRun build2 = jenkinsRule.assertBuildStatusSuccess(job2.scheduleBuild2(0));
         RunExt r2 = RunExt.create(build2);
         String runKey2 = build2.getExternalizableId();
@@ -81,8 +81,8 @@ public class CachingTest {
         WorkflowJob job = jenkinsRule.jenkins.createProject(WorkflowJob.class, "BlinkinJob");
         job.setDefinition(new CpsFlowDefinition("" +
                 "stage 'first' \n" +
-                "echo 'done'"
-        ));
+                "echo 'done'",
+                true));
         WorkflowRun build = jenkinsRule.assertBuildStatusSuccess(job.scheduleBuild2(0));
         jenkinsRule.assertBuildStatusSuccess(build);
         RunExt r = RunExt.create(build);
@@ -93,8 +93,8 @@ public class CachingTest {
         WorkflowJob job2 = jenkinsRule.jenkins.createProject(WorkflowJob.class, "StableJob");
         job2.setDefinition(new CpsFlowDefinition("" +
                 "stage 'second' \n" +
-                "echo 'done'"
-        ));
+                "echo 'done'",
+                true));
         WorkflowRun build2 = jenkinsRule.assertBuildStatusSuccess(job2.scheduleBuild2(0));
         RunExt r2 = RunExt.create(build2);
         String runKey2 = build2.getExternalizableId();

--- a/rest-api/src/test/java/com/cloudbees/workflow/rest/endpoints/FlowNodeAPITest.java
+++ b/rest-api/src/test/java/com/cloudbees/workflow/rest/endpoints/FlowNodeAPITest.java
@@ -72,7 +72,7 @@ public class FlowNodeAPITest {
                 "   echo ('Testing'); " +
                 "   stage ('Deploy'); " +
                 "   echo ('Deploying'); " +
-                "}"));
+                "}", true));
 
         QueueTaskFuture<WorkflowRun> build = job.scheduleBuild2(0);
         jenkinsRule.assertBuildStatusSuccess(build);
@@ -163,7 +163,7 @@ public class FlowNodeAPITest {
                 "   error ('echo Testing'); " +
                 "   stage ('Deploy'); " +
                 "   error ('echo Deploying'); " +
-                "}"));
+                "}", true));
 
         QueueTaskFuture<WorkflowRun> build = job.scheduleBuild2(0);
         jenkinsRule.assertBuildStatus(Result.FAILURE, build.get());

--- a/rest-api/src/test/java/com/cloudbees/workflow/rest/endpoints/InputStepTest.java
+++ b/rest-api/src/test/java/com/cloudbees/workflow/rest/endpoints/InputStepTest.java
@@ -64,7 +64,7 @@ public class InputStepTest {
                 "   sleep (1); " +
                 "   input(message: 'Is the build okay?') " +
                 "   error ('break'); " +
-                "}"));
+                "}", true));
 
         // schedule the workflow and then wait for it to enter
         // the pending input state
@@ -114,7 +114,7 @@ public class InputStepTest {
 
         InputStream sampleFlowRes = getClass().getResourceAsStream("sample-flow.groovy");
         String sampleFlow = IOUtils.toString(sampleFlowRes);
-        job.setDefinition(new CpsFlowDefinition(sampleFlow));
+        job.setDefinition(new CpsFlowDefinition(sampleFlow, true));
 
         // Start the job and wait for it to pause at the input action
         QueueTaskFuture<WorkflowRun> build = job.scheduleBuild2(0);

--- a/rest-api/src/test/java/com/cloudbees/workflow/rest/endpoints/JobAndRunAPITest.java
+++ b/rest-api/src/test/java/com/cloudbees/workflow/rest/endpoints/JobAndRunAPITest.java
@@ -79,7 +79,7 @@ public class JobAndRunAPITest {
                 "     archive(includes: 'file.txt'); " +
                 "     echo ('Deploying'); " +
                 "   } \n" +
-                "}"));
+                "}", true));
 
         QueueTaskFuture<WorkflowRun> build = job.scheduleBuild2(0);
         jenkinsRule.assertBuildStatusSuccess(build);
@@ -129,7 +129,7 @@ public class JobAndRunAPITest {
                 "     writeFile file: 'file.txt', text:'content'; " +
                 "     archive(includes: 'file.txt'); " +
                 "   echo ('Deploying'); " +
-                "}"));
+                "}", true));
 
         QueueTaskFuture<WorkflowRun> build = job.scheduleBuild2(0);
         jenkinsRule.assertBuildStatusSuccess(build);
@@ -156,7 +156,7 @@ public class JobAndRunAPITest {
         job.setDefinition(new CpsFlowDefinition("" +
                 "stage 'empty'\n" +
                 "stage 'nope' \n" +
-                "echo \"I'm passing\"\n"));
+                "echo \"I'm passing\"\n", true));
 
         QueueTaskFuture<WorkflowRun> build = job.scheduleBuild2(0);
         jenkinsRule.assertBuildStatus(Result.SUCCESS, build.get());
@@ -200,8 +200,8 @@ public class JobAndRunAPITest {
                 "}\n" +
                 "stage 'three'\n" +
                 "echo 'we are going to crash....'\n" +
-                "throw new Exception(\"crash!!!\")\n"
-                ));
+                "throw new Exception(\"crash!!!\")\n",
+                true));
 
         QueueTaskFuture<WorkflowRun> build = job.scheduleBuild2(0);
         jenkinsRule.assertBuildStatus(Result.FAILURE, build.get());
@@ -246,7 +246,7 @@ public class JobAndRunAPITest {
                 "}\n" +
                 "\n" +
                 "stage \"and now keep passing\"\n" +
-                "echo \"still passing\""));
+                "echo \"still passing\"", true));
 
         QueueTaskFuture<WorkflowRun> build = job.scheduleBuild2(0);
         jenkinsRule.assertBuildStatus(Result.FAILURE, build.get());
@@ -523,8 +523,8 @@ public class JobAndRunAPITest {
                 "currentBuild.result = 'UNSTABLE'\n" +
                 "echo 'ran things'\n" +
                 "stage 'end'\n" +
-                "echo 'done'"
-        ));
+                "echo 'done'",
+                true));
         QueueTaskFuture<WorkflowRun> build = passUnstable.scheduleBuild2(0);
         jenkinsRule.assertBuildStatus(Result.UNSTABLE, build.get());
         JenkinsRule.WebClient webClient = jenkinsRule.createWebClient();
@@ -556,7 +556,7 @@ public class JobAndRunAPITest {
                 "catch (Exception e) {\n" +
                 "    currentBuild.result = 'UNSTABLE'    \n" +
                 "    echo 'eaten error!' \n" +
-                "}"));
+                "}", true));
 
         QueueTaskFuture<WorkflowRun> build = failUnstable.scheduleBuild2(0);
         jenkinsRule.assertBuildStatus(Result.UNSTABLE, build.get());
@@ -584,8 +584,8 @@ public class JobAndRunAPITest {
                 "    error('Trusted Grand Maester Pycelle')\n" +
                 "} catch (Exception e) {\n" +
                 "    echo 'It was a trap - Tyriowned!'\n" +
-                "}"
-        ));
+                "}",
+                true));
         QueueTaskFuture<WorkflowRun> build = oneStageCatch.scheduleBuild2(0);
         jenkinsRule.assertBuildStatusSuccess(build);
         JenkinsRule.WebClient webClient = jenkinsRule.createWebClient();
@@ -613,8 +613,8 @@ public class JobAndRunAPITest {
                 "    echo 'Ran away to Dragonstone'\n" +
                 "}\n" +
                 "stage 'Flee to the North'\n" +
-                "echo 'Helped defeat the Wildlings'"
-        ));
+                "echo 'Helped defeat the Wildlings'",
+                true));
         QueueTaskFuture<WorkflowRun> build = multiStageCatch.scheduleBuild2(0);
         jenkinsRule.assertBuildStatusSuccess(build);
         JenkinsRule.WebClient webClient = jenkinsRule.createWebClient();
@@ -643,8 +643,8 @@ public class JobAndRunAPITest {
                 "} catch (Exception ex) {\n" +
                 "    echo 'Stage failed'\n" +
                 "    currentBuild.result = 'FAILURE'\n" +
-                "}"
-        ));
+                "}",
+                true));
 
         QueueTaskFuture<WorkflowRun> build = job.scheduleBuild2(0);
         jenkinsRule.assertBuildStatus(Result.FAILURE, build.get());

--- a/rest-api/src/test/java/com/cloudbees/workflow/rest/endpoints/ParallelStepTest.java
+++ b/rest-api/src/test/java/com/cloudbees/workflow/rest/endpoints/ParallelStepTest.java
@@ -63,7 +63,7 @@ public class ParallelStepTest {
                 "}";
 
         // System.out.println(script);
-        job.setDefinition(new CpsFlowDefinition(script));
+        job.setDefinition(new CpsFlowDefinition(script, true));
 
         QueueTaskFuture<WorkflowRun> build = job.scheduleBuild2(0);
         build.waitForStart();

--- a/ui/src/test/java/com/cloudbees/workflow/ui/view/BuildArtifactsTest.java
+++ b/ui/src/test/java/com/cloudbees/workflow/ui/view/BuildArtifactsTest.java
@@ -59,7 +59,7 @@ public class BuildArtifactsTest extends AbstractPhantomJSTest {
                 "   stage ('Archiving'); " +
                 "   sh('mkdir targs && echo hello > targs/hello1.txt && echo hello > targs/hello2.txt'); " +
                 "   archive(includes: 'targs/*.txt'); " +
-                "}"));
+                "}", true));
 
         QueueTaskFuture<WorkflowRun> build = job.scheduleBuild2(0);
         jenkinsRule.assertBuildStatusSuccess(build);

--- a/ui/src/test/java/com/cloudbees/workflow/ui/view/FailedJobTest.java
+++ b/ui/src/test/java/com/cloudbees/workflow/ui/view/FailedJobTest.java
@@ -59,7 +59,7 @@ public class FailedJobTest extends AbstractPhantomJSTest {
                 "node {" +
                 "   stage ('Build'); " +
                 "   sh ('blah'); " +
-                "}"));
+                "}", true));
 
         QueueTaskFuture<WorkflowRun> build = job.scheduleBuild2(0);
         jenkinsRule.assertBuildStatus(Result.FAILURE, build.get());

--- a/ui/src/test/java/com/cloudbees/workflow/ui/view/PausedJobTest.java
+++ b/ui/src/test/java/com/cloudbees/workflow/ui/view/PausedJobTest.java
@@ -61,7 +61,7 @@ public class PausedJobTest extends AbstractPhantomJSTest {
                 "   stage ('Build'); " +
                 "   echo ('build'); " +
                 "   input (message: 'Is the build okay?'); " +
-                "}"));
+                "}", true));
 
         QueueTaskFuture<WorkflowRun> q = job.scheduleBuild2(0);
         WorkflowRun b = q.getStartCondition().get();

--- a/ui/src/test/java/com/cloudbees/workflow/ui/view/StagePopupsTest.java
+++ b/ui/src/test/java/com/cloudbees/workflow/ui/view/StagePopupsTest.java
@@ -60,7 +60,7 @@ public class StagePopupsTest extends AbstractPhantomJSTest {
                 "   stage ('Build'); " +
                 "   sh ('ls'); " +
                 "   sh ('blah'); " +
-                "}"));
+                "}", true));
 
         QueueTaskFuture<WorkflowRun> build = job.scheduleBuild2(0);
         jenkinsRule.assertBuildStatus(Result.FAILURE, build.get());

--- a/ui/src/test/java/com/cloudbees/workflow/ui/view/WorkflowStageViewActionTest.java
+++ b/ui/src/test/java/com/cloudbees/workflow/ui/view/WorkflowStageViewActionTest.java
@@ -64,7 +64,7 @@ public class WorkflowStageViewActionTest extends AbstractPhantomJSTest {
                 "   sh ('echo Testing'); " +
                 "   stage ('Deploy'); " +
                 "   sh ('echo Deploying'); " +
-                "}"));
+                "}", true));
 
         QueueTaskFuture<WorkflowRun> build = job.scheduleBuild2(0);
         jenkinsRule.assertBuildStatusSuccess(build);


### PR DESCRIPTION
While looking at the test suite for this plugin, I noticed the `CpsFlowDefinition`s in the tests don't consistently use the script security sandbox. Using the script security sandbox results in a more realistic environment given that the script security sandbox should always be enabled in production.

In this change, I replaced any usages of the deprecated single-argument constructor for `CpsFlowDefinition` with usages of the non-deprecated two-argument constructor, passing in `true` as the second argument in order to always enable the script security sandbox.