### PR TITLE
Update plugin POM and fix failing tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>2.22</version>
+        <version>3.48</version>
     </parent>
 
     <groupId>org.jenkins-ci.plugins.pipeline-stage-view</groupId>
@@ -36,7 +36,7 @@
     <version>2.12-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Pipeline Stage View Plugin: Parent POM</name>
-    <url>https://wiki.jenkins-ci.org/display/JENKINS/Pipeline+Stage+View+Plugin</url>
+    <url>https://wiki.jenkins.io/display/JENKINS/Pipeline+Stage+View+Plugin</url>
 
     <scm>
         <connection>scm:git:git://github.com/jenkinsci/pipeline-stage-view-plugin.git</connection>
@@ -46,21 +46,21 @@
     </scm>
 
     <properties>
-        <jenkins.version>1.642.3</jenkins.version>
-        <java.level>7</java.level>
+        <jenkins.version>2.60.3</jenkins.version>
+        <java.level>8</java.level>
         <workflow.version>2.0</workflow.version>
     </properties>
 
     <repositories>
         <repository>
             <id>repo.jenkins-ci.org</id>
-            <url>http://repo.jenkins-ci.org/public/</url>
+            <url>https://repo.jenkins-ci.org/public/</url>
         </repository>
     </repositories>
     <pluginRepositories>
         <pluginRepository>
             <id>repo.jenkins-ci.org</id>
-            <url>http://repo.jenkins-ci.org/public/</url>
+            <url>https://repo.jenkins-ci.org/public/</url>
         </pluginRepository>
     </pluginRepositories>
 

--- a/rest-api/pom.xml
+++ b/rest-api/pom.xml
@@ -36,36 +36,35 @@
     <version>2.12-SNAPSHOT</version>
     <name>Pipeline: REST API Plugin</name>
     <description>Provides a REST API to access pipeline and pipeline run data</description>
-    <url>https://wiki.jenkins-ci.org/display/JENKINS/Pipeline+Stage+View+Plugin</url> <!-- TODO update -->
+    <url>https://wiki.jenkins-ci.org/display/JENKINS/Pipeline+Stage+View+Plugin</url>
     <packaging>hpi</packaging>
 
 
     <dependencies>
         <dependency>
-            <!-- Temporary version due to upstream dependency, just until that is released -->
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-api</artifactId>
-            <version>2.15</version>
+            <version>2.24</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>pipeline-graph-analysis</artifactId>
-            <version>1.1</version>
+            <version>1.4</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-job</artifactId>
-            <version>2.0</version>
+            <version>2.12</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>pipeline-stage-step</artifactId>
-            <version>2.2</version>
+            <version>2.3</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>pipeline-input-step</artifactId>
-            <version>2.0</version>
+            <version>2.8</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
@@ -83,13 +82,19 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-basic-steps</artifactId>
-            <version>2.0</version>
+            <version>2.6</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-durable-task-step</artifactId>
-            <version>2.0</version>
+            <version>2.16</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins.workflow</groupId>
+            <artifactId>workflow-scm-step</artifactId>
+            <version>2.4</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -100,7 +105,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-step-api</artifactId>
-            <version>2.10</version>
+            <version>2.14</version>
         </dependency>
 
         <dependency>

--- a/rest-api/src/main/java/com/cloudbees/workflow/flownode/FlowNodeUtil.java
+++ b/rest-api/src/main/java/com/cloudbees/workflow/flownode/FlowNodeUtil.java
@@ -87,7 +87,7 @@ public class FlowNodeUtil {
         }
 
         public static List<CacheExtension> all() {
-            Jenkins myJenkins = Jenkins.getInstance();
+            Jenkins myJenkins = Jenkins.getInstanceOrNull();
             if ( myJenkins == null) {
                 return FALLBACK_CACHES;
             } else {

--- a/rest-api/src/main/java/com/cloudbees/workflow/rest/external/PendingInputActionsExt.java
+++ b/rest-api/src/main/java/com/cloudbees/workflow/rest/external/PendingInputActionsExt.java
@@ -34,6 +34,7 @@ import org.jenkinsci.plugins.workflow.support.steps.input.InputStepExecution;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.TimeoutException;
 
 /**
  * @author <a href="mailto:tom.fennelly@gmail.com">tom.fennelly@gmail.com</a>
@@ -127,16 +128,20 @@ public class PendingInputActionsExt {
         InputAction inputAction = run.getAction(InputAction.class);
 
         if (inputAction != null) {
-            InputStepExecution execution = inputAction.getExecution(inputId);
-            if (execution != null) {
-                List<ParameterDefinition> inputParamDefs = execution.getInput().getParameters();
-                List<InputParameterDefExt> inputParameters = new ArrayList<InputParameterDefExt>();
+            try {
+                InputStepExecution execution = inputAction.getExecution(inputId);
+                if (execution != null) {
+                    List<ParameterDefinition> inputParamDefs = execution.getInput().getParameters();
+                    List<InputParameterDefExt> inputParameters = new ArrayList<InputParameterDefExt>();
 
-                for (ParameterDefinition inputParamDef : inputParamDefs) {
-                    inputParameters.add(new InputParameterDefExt(inputParamDef));
+                    for (ParameterDefinition inputParamDef : inputParamDefs) {
+                        inputParameters.add(new InputParameterDefExt(inputParamDef));
+                    }
+
+                    return inputParameters;
                 }
-
-                return inputParameters;
+            } catch (InterruptedException | TimeoutException e) {
+                throw new RuntimeException(e);
             }
         }
 

--- a/rest-api/src/main/java/com/cloudbees/workflow/rest/external/RunExt.java
+++ b/rest-api/src/main/java/com/cloudbees/workflow/rest/external/RunExt.java
@@ -45,6 +45,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
+import java.util.concurrent.TimeoutException;
 
 /**
  * External API response object for pipeline run
@@ -344,9 +345,13 @@ public class RunExt {
     public static boolean isPendingInput(WorkflowRun run) {
         InputAction inputAction = run.getAction(InputAction.class);
         if (inputAction != null) {
-            List<InputStepExecution> executions = inputAction.getExecutions();
-            if (executions != null && !executions.isEmpty()) {
-                return true;
+            try {
+                List<InputStepExecution> executions = inputAction.getExecutions();
+                if (executions != null && !executions.isEmpty()) {
+                    return true;
+                }
+            } catch (InterruptedException | TimeoutException e) {
+                throw new RuntimeException(e);
             }
         }
         return false;

--- a/ui/pom.xml
+++ b/ui/pom.xml
@@ -38,7 +38,7 @@
     <description>Provides a swimlane view of the different stages in a pipeline.
     </description>
     <packaging>hpi</packaging>
-    <url>https://wiki.jenkins-ci.org/display/JENKINS/Pipeline+Stage+View+Plugin</url>
+    <url>https://wiki.jenkins.io/display/JENKINS/Pipeline+Stage+View+Plugin</url>
     <properties>
         <npm.loglevel>--silent</npm.loglevel>
     </properties>
@@ -51,8 +51,13 @@
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
+            <artifactId>workflow-api</artifactId>
+            <version>2.24</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-job</artifactId>
-            <version>2.0</version>
+            <version>2.12</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.ui</groupId>
@@ -62,7 +67,7 @@
         <dependency>
             <groupId>org.jenkins-ci.ui</groupId>
             <artifactId>handlebars</artifactId>
-            <version>1.1</version>
+            <version>1.1.1</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.ui</groupId>
@@ -72,7 +77,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>script-security</artifactId>
-            <version>1.18</version>
+            <version>1.26</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -84,7 +89,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-scm-step</artifactId>
-            <version>2.1</version>
+            <version>2.4</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/ui/src/test/resources/view/pipeline_staged/render/03_rest_api_runs_checkpoint_rerun.html
+++ b/ui/src/test/resources/view/pipeline_staged/render/03_rest_api_runs_checkpoint_rerun.html
@@ -76,7 +76,7 @@
               <div class="cell-color">
                 <div class="stage-wrapper">
                     <div class="duration">
-                        <span style="font-size: em; opacity: NaN;">NaNy NaNd</span>
+                        <span style="font-size: em; opacity: NaN;">0ms</span>
                     </div>
                 </div>
               </div>
@@ -85,7 +85,7 @@
               <div class="cell-color">
                 <div class="stage-wrapper">
                     <div class="duration">
-                        <span style="font-size: em; opacity: NaN;">NaNy NaNd</span>
+                        <span style="font-size: em; opacity: NaN;">0ms</span>
                     </div>
                 </div>
               </div>

--- a/ui/src/test/resources/view/pipeline_staged/render/04_rest_api_runs_failed.html
+++ b/ui/src/test/resources/view/pipeline_staged/render/04_rest_api_runs_failed.html
@@ -110,7 +110,7 @@
           <div class="cell-color">
             <div class="stage-wrapper">
                 <div class="duration">
-                    <span style="font-size: 1em; opacity: 0.5;">NaNy NaNd</span>
+                    <span style="font-size: 1em; opacity: 0.5;">0ms</span>
                 </div>
                 <div class="extension-dock"></div>
             </div>

--- a/ui/src/test/resources/view/pipeline_staged/render/expected.html
+++ b/ui/src/test/resources/view/pipeline_staged/render/expected.html
@@ -189,7 +189,7 @@
           <div class="cell-color">
             <div class="stage-wrapper">
                 <div class="duration">
-                    <span style="font-size: 1em; opacity: 0.5;">NaNy NaNd</span>
+                    <span style="font-size: 1em; opacity: 0.5;">0ms</span>
                 </div>
                 <div class="extension-dock"></div>
             </div>
@@ -199,7 +199,7 @@
           <div class="cell-color">
             <div class="stage-wrapper">
                 <div class="duration">
-                    <span style="font-size: 1em; opacity: 0.5;">NaNy NaNd</span>
+                    <span style="font-size: 1em; opacity: 0.5;">0ms</span>
                 </div>
                 <div class="extension-dock"></div>
             </div>


### PR DESCRIPTION
Bumps the [plugin parent POM](https://github.com/jenkinsci/plugin-pom) from 2.22 to 3.48.

See [the changelog](https://github.com/jenkinsci/plugin-pom/blob/master/CHANGELOG.md) and the full diff in [the compare view](https://github.com/jenkinsci/plugin-pom/compare/plugin-2.22...plugin-3.48).

I took this opportunity to modernize the plugin by bumping the minimum Java version to Java 8 and core 2.60.3 or later. This entailed bumping the minimum pipeline plugin dependencies as well, and fixing some callers in the REST API to adapt to the exceptions thrown by newer versions of the Pipeline Input Step plugin.

Also fixed some tests that appear to have been broken by #68.