### PR TITLE
JENKINS-46096 display the stage view as inline-block

### DIFF
--- a/rest-api/src/test/java/com/cloudbees/workflow/rest/endpoints/JobAndRunAPITest.java
+++ b/rest-api/src/test/java/com/cloudbees/workflow/rest/endpoints/JobAndRunAPITest.java
@@ -36,7 +36,6 @@ import com.cloudbees.workflow.util.JSONReadWrite;
 import com.gargoylesoftware.htmlunit.Page;
 import hudson.model.Action;
 import hudson.model.Result;
-import hudson.model.Run;
 import hudson.model.queue.QueueTaskFuture;
 import org.jenkinsci.plugins.workflow.actions.TimingAction;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
@@ -53,6 +52,9 @@ import org.xml.sax.SAXException;
 import java.io.IOException;
 import java.net.URLEncoder;
 import java.util.List;
+
+import static java.lang.System.getProperty;
+import static org.junit.Assume.assumeFalse;
 
 /**
  * Test the raw job/run APIs
@@ -186,6 +188,9 @@ public class JobAndRunAPITest {
     @Issue("JENKINS-40162")  // Zero duration for run
     @Test
     public void testDuration0EdgeCase() throws Exception {
+        // Test can't run on windows machines (JENKINS-33708). The flow definition contains the sh command.
+        assumeFalse(getProperty("os.name").toLowerCase().startsWith("win"));
+
         WorkflowJob job = jenkinsRule.jenkins.createProject(WorkflowJob.class, "DurationBug");
 
         job.setDefinition(new CpsFlowDefinition("" +

--- a/ui/src/main/less/stageview_adjunct.less
+++ b/ui/src/main/less/stageview_adjunct.less
@@ -2,6 +2,7 @@
 .cbwf-stage-view {
   padding: 15px 0;
   clear: right;
+  display: inline-block;
 }
 
 // Selectively import some twitter bootstrap styles.  Namespace them too.

--- a/ui/src/test/js/helper.js
+++ b/ui/src/test/js/helper.js
@@ -124,8 +124,8 @@ exports.trim = function(str) {
 }
 
 exports.compareMultilineText = function(text1, text2, trimLines) {
-    var text1Lines = text1.split(/^/m);
-    var text2Lines = text2.split(/^/m);
+    var text1Lines = text1.match(/[^\r\n]+/g);
+    var text2Lines = text2.match(/[^\r\n]+/g);
 
     if (text1Lines.length !== text2Lines.length) {
         console.log("Text1 has " + text1Lines.length + " lines of text, while Text2 has " + text2Lines.length);

--- a/ui/src/test/js/view/run-changesets-spec.js
+++ b/ui/src/test/js/view/run-changesets-spec.js
@@ -20,7 +20,7 @@ describe("view/run-changesets-spec", function () {
 //            helper.log('[' + expectedFrag + ']');
 //            helper.compareMultilineText(veiwFarg.html(), expectedFrag);
 
-            expect(veiwFarg.html().replace(/\r?\n/g, '\n')).toEqual(expectedFrag).replace(/\r?\n/g, '\n');
+            expect(veiwFarg.html().replace(/\r?\n/g, '\n')).toEqual(expectedFrag.replace(/\r?\n/g, '\n'));
 
             done();
         });

--- a/ui/src/test/js/view/run-changesets-spec.js
+++ b/ui/src/test/js/view/run-changesets-spec.js
@@ -12,7 +12,7 @@ describe("view/run-changesets-spec", function () {
             var run_changeset_model = helper.requireTestRes('model/run_changesets/01_run_changeset_post_model');
             var templates = helper.require('view/templates');
 
-            var veiwFarg = templates.apply('run-changeset', run_changeset_model);
+            var viewFrag = templates.apply('run-changeset', run_changeset_model);
 
             var expectedFrag = helper.requireTestRes('view/run_changesets/expected_01.html');
 //            helper.log('[' + veiwFarg.html() + ']');
@@ -20,7 +20,10 @@ describe("view/run-changesets-spec", function () {
 //            helper.log('[' + expectedFrag + ']');
 //            helper.compareMultilineText(veiwFarg.html(), expectedFrag);
 
-            expect(veiwFarg.html().replace(/\r?\n/g, '\n')).toEqual(expectedFrag.replace(/\r?\n/g, '\n'));
+            var currentHtml = viewFrag.html().replace(/\r?\n/g, '\n');
+            var expectedHtml = expectedFrag.replace(/\r?\n/g, '\n');
+
+            expect(currentHtml).toEqual(expectedHtml);
 
             done();
         });

--- a/ui/src/test/js/view/run-changesets-spec.js
+++ b/ui/src/test/js/view/run-changesets-spec.js
@@ -20,7 +20,7 @@ describe("view/run-changesets-spec", function () {
 //            helper.log('[' + expectedFrag + ']');
 //            helper.compareMultilineText(veiwFarg.html(), expectedFrag);
 
-            expect(veiwFarg.html()).toEqual(expectedFrag);
+            expect(veiwFarg.html().replace(/\r?\n/g, '\n')).toEqual(expectedFrag).replace(/\r?\n/g, '\n');
 
             done();
         });


### PR DESCRIPTION
To avoid overlay of stage view over test result and other graphs and to
not display the stage swim lanes on the bottom of the page.