### PR TITLE
[JENKINS-43556] Add sanity check for cached runs

### DIFF
--- a/rest-api/src/main/java/com/cloudbees/workflow/flownode/FlowNodeUtil.java
+++ b/rest-api/src/main/java/com/cloudbees/workflow/flownode/FlowNodeUtil.java
@@ -100,7 +100,13 @@ public class FlowNodeUtil {
     public static RunExt getCachedRun(@Nonnull WorkflowRun run) {
         RunExt cachedRun = CacheExtension.all().get(0).getRunCache().getIfPresent(run.getExternalizableId());
         if (cachedRun != null) {
-            return cachedRun;
+            // Sanity check the cache see JENKINS-43556
+            StatusExt status = StatusExt.valueOf(run.getResult());
+            if (cachedRun.getStatus().equals(status)) {
+                return cachedRun;
+            } else {
+                CacheExtension.all().get(0).getRunCache().invalidate(run.getExternalizableId());
+            }
         }
         return null;
     }

--- a/rest-api/src/main/java/com/cloudbees/workflow/rest/external/RunExt.java
+++ b/rest-api/src/main/java/com/cloudbees/workflow/rest/external/RunExt.java
@@ -366,19 +366,7 @@ public class RunExt {
             setStatus(StatusExt.valueOf(execution.getCauseOfFailure()));
         } else if (execution.isComplete()) {
             Result r = run.getResult();
-            if (r == Result.NOT_BUILT) {
-                setStatus(StatusExt.NOT_EXECUTED);
-            } else if (r == Result.ABORTED) {
-                setStatus(StatusExt.ABORTED);
-            } else if (r == Result.FAILURE ) {
-                setStatus(StatusExt.FAILED);
-            } else if (r == Result.UNSTABLE ) {
-                setStatus(StatusExt.UNSTABLE);
-            } else if (r == Result.SUCCESS) {
-                setStatus(StatusExt.SUCCESS);
-            } else {
-                setStatus(StatusExt.FAILED);
-            }
+            setStatus(StatusExt.valueOf(r));
         } else if (isPendingInput(run)) {
             setStatus(StatusExt.PAUSED_PENDING_INPUT);
         } else {

--- a/rest-api/src/main/java/com/cloudbees/workflow/rest/external/StatusExt.java
+++ b/rest-api/src/main/java/com/cloudbees/workflow/rest/external/StatusExt.java
@@ -27,8 +27,9 @@ import org.jenkinsci.plugins.workflow.actions.ErrorAction;
 import org.jenkinsci.plugins.workflow.pipelinegraphanalysis.GenericStatus;
 import org.jenkinsci.plugins.workflow.steps.FlowInterruptedException;
 
+import hudson.model.Result;
+
 import javax.annotation.CheckForNull;
-import javax.annotation.Nonnull;
 
 /**
  * @author <a href="mailto:tom.fennelly@gmail.com">tom.fennelly@gmail.com</a>
@@ -55,6 +56,22 @@ public enum StatusExt {
             return StatusExt.ABORTED;
         } else {
             return StatusExt.FAILED;
+        }
+    }
+
+    public static StatusExt valueOf(Result r) {
+        if (r == Result.NOT_BUILT) {
+            return StatusExt.NOT_EXECUTED;
+        } else if (r == Result.ABORTED) {
+            return StatusExt.ABORTED;
+        } else if (r == Result.FAILURE) {
+            return StatusExt.FAILED;
+        } else if (r == Result.UNSTABLE ) {
+            return StatusExt.UNSTABLE;
+        } else if (r == Result.SUCCESS) {
+            return StatusExt.SUCCESS;
+        } else {
+            throw new IllegalStateException("Illegal Result type: " + r);
         }
     }
 

--- a/rest-api/src/test/java/com/cloudbees/workflow/flownode/CachingTest.java
+++ b/rest-api/src/test/java/com/cloudbees/workflow/flownode/CachingTest.java
@@ -126,7 +126,8 @@ public class CachingTest {
         r.setStatus(StatusExt.FAILED);
         String runKey = build.getExternalizableId();
         cache.put(runKey, r);
-        //Assert invalid cache entry not returned
+        //Assert invalid cache entry not returned and invalidated
         Assert.assertNull(FlowNodeUtil.getCachedRun(build));
+        Assert.assertNull(cache.getIfPresent(runKey));
     }
 }


### PR DESCRIPTION
Signed-off-by: Raihaan Shouhell <raihaan.shouhell@autodesk.com>

Do some sanity checking to ensure that values in the cache are valid and if not invalidate them.

CC: @olamy could you PTAL