### PR TITLE
Fix formatter.time with millis value `undefined` returning "NaNy NaNd"

### DIFF
--- a/ui/src/main/js/util/formatters.js
+++ b/ui/src/main/js/util/formatters.js
@@ -48,7 +48,7 @@ exports.memory = function (amount) {
 }
 
 exports.time = function (millis, numUnitsToShow) {
-    if (millis <= 0 || isNaN(millis)) {
+    if (typeof millis !== 'number' || millis <= 0 || isNaN(millis)) {
         return '0ms';
     }
 


### PR DESCRIPTION
Fix time formatter returning `NaNy NaNd` when `millis` is undefined.

This happens when all visible builds have skipped a stage, and ends up looking like this:

![image](https://user-images.githubusercontent.com/1089216/69934041-e993b980-1524-11ea-9f77-5697077d90cc.png)
