### PR TITLE
For JENKINS-58783: Only color stage start with global status

### DIFF
--- a/ui/src/main/js/view/templates/pipeline-staged.less
+++ b/ui/src/main/js/view/templates/pipeline-staged.less
@@ -54,10 +54,10 @@
     td.UNSTABLE .cell-color {
       background: rgba(230, 230, 9, .2)
     }
-    tr.UNSTABLE .cell-color {
+    tr.UNSTABLE td.stage-start .cell-color {
           background: rgba(230, 230, 9, .2)
     }
-    tr.FAILED .cell-color {
+    tr.FAILED td.stage-start .cell-color {
       background: rgba(255, 50, 0, .1)
     }
     tr.FAILED .FAILED .duration {


### PR DESCRIPTION
This makes it possible to see the status of individual stages.

Currently, the CSS for the global pipeline status overrides the status for each individual step. This change only applies the background color to the "start" stage instead of the complete row.