### PR TITLE
Workaround for GROOVY-8936 (NPE in Exception)

### DIFF
--- a/rest-api/src/main/java/com/cloudbees/workflow/rest/external/ErrorExt.java
+++ b/rest-api/src/main/java/com/cloudbees/workflow/rest/external/ErrorExt.java
@@ -58,7 +58,12 @@ public class ErrorExt {
         Throwable throwable = errorAction.getError();
 
         if (throwable != null) {
-            errorExt.setMessage(throwable.getMessage());
+            try {
+                errorExt.setMessage(throwable.getMessage());
+            } catch (NullPointerException npe) {
+                // Workaround for GROOVY-8936
+                errorExt.setMessage("No message: NullPointerException on .getMessage()");
+            }
             errorExt.setType(throwable.getClass().getName());
         } else {  // Some rare cases, for example serialization problems
             errorExt.setMessage("No message: null Throwable on error");

--- a/rest-api/src/test/java/com/cloudbees/workflow/rest/external/ErrorExtTest.java
+++ b/rest-api/src/test/java/com/cloudbees/workflow/rest/external/ErrorExtTest.java
@@ -1,0 +1,66 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2015, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.cloudbees.workflow.rest.external;
+
+import groovy.lang.MissingPropertyException;
+import org.jenkinsci.plugins.workflow.actions.ErrorAction;
+import org.junit.Test;
+import static org.hamcrest.Matchers.containsString;
+import static org.junit.Assert.assertThat;
+
+public class ErrorExtTest {
+
+    /**
+     * This is a test against an issue which is fixed in Groovy 3.0 (GROOVY-8936) - It might start
+     * failing whenever groovy is updated to a version where this issue is fixed. See
+     * {@link #testErrorExtNoTestNullPointerException()} for a variant of this test against a broken
+     * local class.
+     */
+    @Test
+    public void testErrorExtNoGroovyNullPointerException() {
+        Throwable throwable = new MissingPropertyException(null);
+        ErrorAction errorAction = new ErrorAction(throwable);
+        ErrorExt errorExt = ErrorExt.create(errorAction);
+        assertThat(errorExt.getMessage(),
+                        containsString("No message: NullPointerException"));
+    }
+
+    @Test
+    public void testErrorExtNoTestNullPointerException() {
+        Throwable throwable = new BrokenException();
+        ErrorAction errorAction = new ErrorAction(throwable);
+        ErrorExt errorExt = ErrorExt.create(errorAction);
+        assertThat(errorExt.getMessage(),
+                        containsString("No message: NullPointerException"));
+    }
+
+    private static class BrokenException extends Exception {
+        private static final long serialVersionUID = 1L;
+
+        @Override
+        public String getMessage() {
+            throw new NullPointerException("violating contract");
+        }
+    }
+}


### PR DESCRIPTION
When MissingPropertyException is constructed with the "type" parameter
being "null" (for example restoring a serialized pipeline step with this
exception, but the class isn't available anymore), trying to access the
pipeline stage view will lead to a NullPointerException, because
GROOVY-8936 isn't fixed in the Groovy version shipped with Jenkins.

The problem is fixed in beta versions of Groovy 3.0, but it will probably take a long time for this to arrive in Jenkins. (See https://github.com/apache/groovy/pull/844)

I can provide details on how this happens if someone is interested.

Pinging @jglick since he provided the fix to Groovy