### PR TITLE
Avoid superfluous warnings

### DIFF
--- a/ui/src/main/js/view/pipeline-staged.js
+++ b/ui/src/main/js/view/pipeline-staged.js
@@ -170,7 +170,9 @@ function addExtensionPoints(onElement, runGroupData) {
             var stageId = stage.attr('data-stageId');
 
             if (!stageId) {
-                console.warn('No "data-stageId" on stage.');
+                if (!stage.hasClass('NOT_EXECUTED')) {
+                    console.warn('No "data-stageId" on stage.');
+                }
                 return;
             }
 


### PR DESCRIPTION
The function `addExtensionPoints` logs warnings for stages' `<td>` elements that do not have a `data-stageId` attribute. In theory, all stages should have one. In practice, they only get their ID once they are started. Stages that are already pre-rendered as `NOT_EXECUTED` don't have one, though, and lead to lots of superfluous warnings in the concole logs.