### PR TITLE
Added the NOT_EXECUTED status

### DIFF
--- a/ui/src/main/js/view/templates/pipeline-staged.less
+++ b/ui/src/main/js/view/templates/pipeline-staged.less
@@ -411,6 +411,9 @@
   .FAILED .jobName .badge {
     background-color: @error-highlight;
   }
+  .NOT_EXECUTED .jobName .badge {
+      background-color: @error-highlight;
+   }
 
   .stage-cell.PENDING_START .stage-wrapper {
     border: none;


### PR DESCRIPTION
There is a separate status of NOT_EXECUTED in the code but that is not accounted for in the javascript and so it was defaulting to "SUCCESS" which is pretty clearly not right.

Sorry no tests as I am not really sure how this would be tested to begin with but with local testing I can force a NOT_EXECUTED status with the code mentioned in the Jira and now it turns red