### PR TITLE
Use icon that is transparent - dark theme compatibility

### DIFF
--- a/ui/src/main/java/com/cloudbees/workflow/ui/view/PluginImpl.java
+++ b/ui/src/main/java/com/cloudbees/workflow/ui/view/PluginImpl.java
@@ -40,6 +40,6 @@ public class PluginImpl extends Plugin {
         super.start();
 
         // Register the medium (24x24) icons...
-        IconSet.icons.addIcon(new Icon("icon-workflow-stage icon-md", "24x24/search.gif", Icon.ICON_MEDIUM_STYLE));
+        IconSet.icons.addIcon(new Icon("icon-workflow-stage icon-md", "24x24/search.png", Icon.ICON_MEDIUM_STYLE));
     }
 }


### PR DESCRIPTION
Fixes https://github.com/jenkinsci/dark-theme/issues/4

cc @oleg-nenashev @olamy 

Before:

![image](https://user-images.githubusercontent.com/21194782/83018467-475d1600-a01d-11ea-8dd2-4d79fa42e8ae.png)

After:

![image](https://user-images.githubusercontent.com/21194782/83921014-5fe3d380-a775-11ea-9314-2271ee659573.png)
