### PR TITLE
[JENKINS-63516] Do not test password parameters with the input step

### DIFF
--- a/rest-api/src/test/java/com/cloudbees/workflow/rest/endpoints/InputStepTest.java
+++ b/rest-api/src/test/java/com/cloudbees/workflow/rest/endpoints/InputStepTest.java
@@ -130,7 +130,6 @@ public class InputStepTest {
 
         addNVP(inputNVPs, "Run test suites?", false);
         addNVP(inputNVPs, "Enter some text", "Hello World");
-        addNVP(inputNVPs, "Enter a password", "guess-again");
         addNVP(inputNVPs, "Take your pick", "Choice 2");
 
         // The input NVPs need to be added to a JSON Object that contains a single
@@ -150,7 +149,6 @@ public class InputStepTest {
         // The test flow just echos the values from the outcome.
         jenkinsRule.assertLogContains("P1: false", run);
         jenkinsRule.assertLogContains("P2: Hello World", run);
-        jenkinsRule.assertLogContains("P3: guess-again", run);
         jenkinsRule.assertLogContains("P4: Choice 2", run);
     }
 

--- a/rest-api/src/test/resources/com/cloudbees/workflow/rest/endpoints/sample-flow.groovy
+++ b/rest-api/src/test/resources/com/cloudbees/workflow/rest/endpoints/sample-flow.groovy
@@ -20,12 +20,6 @@ node {
             name: 'Enter some text',
             description: 'A text option'
           ],
-          [ 
-            $class: 'PasswordParameterDefinition',
-            defaultValue: "MyPasswd",
-            name: 'Enter a password',
-            description: 'A password option'
-          ],
           [
             $class: 'ChoiceParameterDefinition', choices: 'Choice 1\nChoice 2\nChoice 3', 
             name: 'Take your pick',
@@ -39,6 +33,5 @@ node {
     // verify that input submit/proceed worked properly.
     echo "P1: ${outcome.get('Run test suites?')}"
     echo "P2: ${outcome.get('Enter some text')}"
-    echo "P3: ${outcome.get('Enter a password')}"
     echo "P4: ${outcome.get('Take your pick')}"
 }


### PR DESCRIPTION
Because of [JENKINS-63516](https://issues.jenkins-ci.org/browse/JENKINS-63516), password parameters are broken with the input step in Jenkins 2.236 and newer. This test is not specifically related to password parameters, so for now it seems best to just remove the password parameter from the test so it does not fail in the PCT against newer versions of Jenkins.