### PR TITLE
Removed unintentional background images

### DIFF
--- a/ui/src/main/less/icons.less
+++ b/ui/src/main/less/icons.less
@@ -16,11 +16,3 @@
     margin: 2px;
   }
 }
-
-.icon-git-logo {
-   background-image: url('@{root}/plugin/git/icons/git-32x32.png');
-}
-
-.icon-workflow-stage {
-   background-image: url('@{root}/plugin/git/icons/git-32x32.png');
-}


### PR DESCRIPTION
This surfaced after #86  / https://github.com/jenkinsci/dark-theme-plugin/issues/4
![image](https://user-images.githubusercontent.com/1105305/93139096-6ffa4000-f6e0-11ea-9931-019e9d126af8.png)

For `icon-workflow-stage` it's clear that the background image was not intentional. For `icon-git-logo` I'm not 100% sure but it seems that the `icon-git-logo` class is never used so this should be safe to remove.