### PR TITLE
Remove JS calculation of width, just use css.

### DIFF
--- a/ui/src/main/js/view/stage-logs.js
+++ b/ui/src/main/js/view/stage-logs.js
@@ -29,9 +29,7 @@ exports.render = function (stageDescription, onElement) {
     var $ = jqProxy.getJQuery();
     var theWindow = require('window-handle').getWindow();
     var stageLogsDom = templates.apply('stage-logs', stageDescription);
-    var winWidth = $(theWindow).width();
     var winHeight = $(theWindow).height();
-    var dialogWidth = Math.min(800, (winWidth * 0.7));
     var dialogHeight = Math.min(800, (winHeight * 0.7));
     var nodeLogFrames = $('.node-log-frame', stageLogsDom);
     var nodeNameBars = $('.node-name', stageLogsDom);
@@ -46,7 +44,6 @@ exports.render = function (stageDescription, onElement) {
             classes: 'cbwf-stage-logs-dialog',
             placement: 'window-visible-top',
             onElement: onElement,
-            width: dialogWidth,
             height: dialogHeight,
             onshow: function() {
                 var header = $('.cbwf-stage-logs-dialog .header');

--- a/ui/src/main/js/view/widgets/dialog/index.js
+++ b/ui/src/main/js/view/widgets/dialog/index.js
@@ -41,13 +41,6 @@ exports.show = function(title, body, options) {
     var headerEl = $('.header', dialog);
     var bodyEl = $('.body', dialog);
 
-    if (options.width) {
-        dialog.css('width', options.width);
-    } else {
-        var winWidth = $(theWindow).width();
-        var popoverWidth = Math.min(800, (winWidth * 0.7));
-        dialog.css('max-width', popoverWidth);
-    }
     if (options.height) {
         dialog.css('height', options.height);
     } else {

--- a/ui/src/main/less/stageview_adjunct.less
+++ b/ui/src/main/less/stageview_adjunct.less
@@ -14,6 +14,7 @@
     color: var(--text-color);
     border-color: var(--panel-border-color);
   }
+  width: calc(100% - 10px);
 }
 
 div.fullscreen#main-panel {


### PR DESCRIPTION
Also set the width to (100%-10px), so this can make better use of the screen real-estate.
Should help address [JENKINS-44470](https://issues.jenkins-ci.org/browse/JENKINS-44470), but could have some more improvements. Similar idea to #41. 

**Screenshots**
<details><summary>Before</summary>

![One](https://user-images.githubusercontent.com/5424257/93296798-90321800-f822-11ea-965e-8c0fb7f2b0ed.png)

![Two](https://user-images.githubusercontent.com/5424257/93297040-13ec0480-f823-11ea-8665-0fc4e2894354.png)

</details>

<details><summary>After</summary>

![One](https://user-images.githubusercontent.com/5424257/93297074-28300180-f823-11ea-8635-a56d0a5c0048.png)

![Two](https://user-images.githubusercontent.com/5424257/93296975-f028be80-f822-11ea-9c5e-2863dc289809.png)

</details>

`calc` is [supported from IE9](https://developer.mozilla.org/en-US/docs/Web/CSS/calc#Browser_compatibility), so hopefully that's fine. But being in the .less may mean that this works in earlier IE versions, but I haven't tested it.

@ssbarnea, @svanoort are you interested in taking a look?