### PR TITLE
Fix background of progress bar in dark theme

### DIFF
--- a/ui/src/main/less/bootstrap-3.2.0/variables.less
+++ b/ui/src/main/less/bootstrap-3.2.0/variables.less
@@ -642,7 +642,7 @@
 //##
 
 //** Background color of the whole progress component
-@progress-bg:                 #f5f5f5;
+@progress-bg:                 var(--background);
 //** Progress bar text color
 @progress-bar-color:          #fff;
 


### PR DESCRIPTION
In the dark theme, the background of the progress bar stays bright. This small fix would solve this problem.
![StageView Progress Bar Background](https://user-images.githubusercontent.com/7957707/94353275-81900000-006f-11eb-994c-26d8ecfbea8a.png)
