### PR TITLE
Remove duplicate background-color

### DIFF
--- a/ui/src/main/js/view/templates/stage-logs.less
+++ b/ui/src/main/js/view/templates/stage-logs.less
@@ -14,7 +14,6 @@
   .node-name {
     padding: 5px 10px;
     background-color: @light-header-background-color;
-    background-color: var(--bigtable-header-bg);
     border-radius: @cbwf-border-radius;
     cursor: pointer;
   }


### PR DESCRIPTION
Remove duplicate background-color since otherwise all nodes get a dark background color which makes them badly readable.