### PR TITLE
[JENKINS-63854] Disable resolveCommitAuthors from stage-view-plugin by default

### DIFF
--- a/rest-api/src/main/java/com/cloudbees/workflow/rest/external/ChangeSetExt.java
+++ b/rest-api/src/main/java/com/cloudbees/workflow/rest/external/ChangeSetExt.java
@@ -51,8 +51,7 @@ public class ChangeSetExt {
      * By setting System Property com.cloudbees.workflow.rest.external.ChangeSetExt.resolveCommitAuthors to 'false'
      * This is a workaround for JENKINS-35484 where user lookup encounters issues */
     private static boolean resolveCommitAuthors() {
-        String prop = System.getProperty(ChangeSetExt.class.getName()+".resolveCommitAuthors");
-        return (StringUtils.isEmpty(prop)|| Boolean.parseBoolean(prop));
+        return Boolean.getBoolean(ChangeSetExt.class.getName()+".resolveCommitAuthors");
     }
 
     public String getKind() {


### PR DESCRIPTION
Ref: https://issues.jenkins-ci.org/browse/JENKINS-63854

There is an important performance issue suffered by instances with a large number of users.

We should disable by default the commit author resolution, because, as far as I know, in the end, the only difference I see is that in the GUI of the stage-view you don’t see the name of the user in Jenkins, but the e-mail address. I have never seen a developer even noticing that the Jenkins administrator disabled this hidden feature which will produce slowness until the user resolution does not happen in an asynchronous mode.

* https://github.com/jenkinsci/pipeline-stage-view-plugin/blob/530ea7ddbcf5a759ed7bf199290411e2c018b9e0/rest-api/src/main/java/com/cloudbees/workflow/rest/external/ChangeSetExt.java#L53

```
java.lang.Thread.State: RUNNABLE
    at java.io.UnixFileSystem.getBooleanAttributes0(Native Method)
    at java.io.UnixFileSystem.getBooleanAttributes(UnixFileSystem.java:242)
    at java.io.File.isFile(File.java:882)
    at hudson.model.User$3.accept(User.java:690)
    at java.io.File.listFiles(File.java:1291)
    at hudson.model.User.getLegacyConfigFilesFor(User.java:687)
    at hudson.model.User.getOrCreate(User.java:431)
    at hudson.model.User.getById(User.java:529)
    at hudson.model.User$UserIDCanonicalIdResolver.resolveCanonicalId(User.java:1071)
    at hudson.model.User.get(User.java:399)
    at hudson.model.User.get(User.java:368)
    at hudson.plugins.git.GitChangeSet.findOrCreateUser(GitChangeSet.java:379)
    at hudson.plugins.git.GitChangeSet.getAuthor(GitChangeSet.java:448)
    at com.cloudbees.workflow.rest.external.ChangeSetExt.mapFields(ChangeSetExt.java:186)
    at com.cloudbees.workflow.rest.external.ChangeSetExt.create(ChangeSetExt.java:161)
```

CC Hello @olamy , would you help to get this PR merged?