### PR TITLE
Fix calc not being escaped

### DIFF
--- a/ui/src/main/less/stageview_adjunct.less
+++ b/ui/src/main/less/stageview_adjunct.less
@@ -14,7 +14,7 @@
     color: var(--text-color);
     border-color: var(--panel-border-color);
   }
-  width: calc(100% - 10px);
+  width: calc(~'100% - 10px');
 }
 
 div.fullscreen#main-panel {


### PR DESCRIPTION
Fix for issue introduced in #107.
I didn't realise I had to escape the calc. Without escaping less will replace it with `calc(90%)`, which is not the same thing.