### PR TITLE
Move width calculation from .cbwf-widget to .cbwf-widget.cbwf-modal

### DIFF
--- a/ui/src/main/less/stageview_adjunct.less
+++ b/ui/src/main/less/stageview_adjunct.less
@@ -14,6 +14,9 @@
     color: var(--text-color);
     border-color: var(--panel-border-color);
   }
+}
+
+.cbwf-widget.cbwf-modal {
   width: calc(~'100% - 10px');
 }
 


### PR DESCRIPTION
This should mean it only affects the larger popup, not the smaller one.

I believe this will fix JENKINS-63892, JENKINS-63914 and JENKINS-63901.

@snago, @TobiX are either of you able to test this with your workflows? I can now see the popup with the `input` stage, but I may have missed something else.