### PR TITLE
Allow input popovers to be bigger

### DIFF
--- a/ui/src/main/js/view/templates/info-action-popover.less
+++ b/ui/src/main/js/view/templates/info-action-popover.less
@@ -58,14 +58,13 @@
 .cbwf-info-action-popover.input {
   width: auto;
   min-width: 10em;
-  max-width: 25em;
+  max-width: 35em;
   position: relative;
   background-color: #fcf8e3;
   border-color: #faebcc;
   color: #8a6d3b;
   box-shadow: 0 3px 10px rgba(0, 0, 0, 0.25);
   text-shadow: #fff 0 0 2px, #fff 0 1px 1px;
-  max-width: 25em;
   padding: 15px;
   margin-bottom: 20px;
   border: 1px solid transparent;

--- a/ui/src/main/js/view/templates/run-input-required.less
+++ b/ui/src/main/js/view/templates/run-input-required.less
@@ -1,7 +1,3 @@
-.cbwf-info-action-popover.run-input-required {
-  min-width: 250px;
-}
-
 .run-input-required {
 
   .message {
@@ -31,7 +27,7 @@
     .inputs {
       margin-right: -15px;
       padding-right: 15px;
-      max-height: 150px;
+      max-height: 20em;
       overflow-y: auto;
     }
     


### PR DESCRIPTION
@VirtualTim inspired me to look at some other QoL improvements for this plugin, this time in the input popup. When adding an input with many options, the popup overflows quite early.

Before:
![grafik](https://user-images.githubusercontent.com/78534/96573286-32379b00-12ce-11eb-8a43-3edad464d00e.png)

After:
![grafik](https://user-images.githubusercontent.com/78534/96573314-3ebbf380-12ce-11eb-8a5d-3060b12a4650.png)

Still fine for small popups:
![grafik](https://user-images.githubusercontent.com/78534/96573598-affba680-12ce-11eb-9c1c-c069dad4d018.png)


There are some other nits I have with this popup, but I haven't found good solutions for them yet:
- Closes too fast when mouse leaves the popup
- Opens too the left of the associated stage, but changing that may push the popup out of the browser window to the right if it is used in later stages...