### PR TITLE
Keep input popovers open for longer

### DIFF
--- a/ui/src/main/js/view/run-input-required.js
+++ b/ui/src/main/js/view/run-input-required.js
@@ -55,6 +55,7 @@ exports.render = function (inputRequiredModel, onElement) {
             hoverBoth: true,
             namespace: 'runInputRequired',
             placement: 'left',
+            hideDelay: 3000,
             onshow: function() {
                 var $ = jqProxy.getJQuery();
                 var pendingActionsTable = $('.pending-input-actions', popoverDom);

--- a/ui/src/main/js/view/widgets/popover/index.js
+++ b/ui/src/main/js/view/widgets/popover/index.js
@@ -202,9 +202,9 @@ Popover.prototype.hover = function() {
     var mouseTracker = jqProxy.getMouseTracker();
     var thisPopover = this;
 
-    var inoutDelay = thisPopover.options.inoutDelay;
-    if (inoutDelay === undefined) {
-        inoutDelay = 500;
+    var hideDelay = thisPopover.options.hideDelay;
+    if (hideDelay === undefined) {
+        hideDelay = 500;
     }
 
     // You can use the hover or mouse enter and leave events, but behavior gets interesting
@@ -273,7 +273,7 @@ Popover.prototype.hover = function() {
                         // re-enter the hover area without the hover disappearing.
                         timeoutHandler.setTimeout(function() {
                             removePopoverChecker(false);
-                        }, Math.floor(inoutDelay * 0.8));
+                        }, hideDelay);
                         return;
                     }
 
@@ -294,7 +294,7 @@ Popover.prototype.hover = function() {
                     remove();
                 });
             }
-        }, inoutDelay);
+        }, 250);
     });
 }
 


### PR DESCRIPTION
In #119 I mentioned that I think the input popovers close too fast and now I had some time to search for the cause.

This splits the "open" and "close" delays (were mixed in `inoutDelay` before) - The open delay is now a fixed 250ms (was 500ms before) and the close delay stays at 500ms by default, but the input popover overrides this to 3s - this makes it much more forgiving to select something in the input popover without it accidentally closing on the user.

Maybe 3s is even too long?