### PR TITLE
JENKINS-64015 Fix Job urls are set to the same color as the background in the Pipeline logs

### DIFF
--- a/ui/src/main/js/view/widgets/dialog/style.less
+++ b/ui/src/main/js/view/widgets/dialog/style.less
@@ -8,7 +8,7 @@
   color: #fff;
   color: var(--bigtable-header-text-color);
 
-  a {
+  a.log-link {
     color: #fff;
     color: var(--bigtable-header-text-color);
   }


### PR DESCRIPTION
Scope contrast fix that was added for JENKINS-63556 / #104 down to just the stage log link, allowing URLs in the logs to render as normal

<details>
  <summary>Before:</summary>
<img src="https://user-images.githubusercontent.com/580744/97761788-8af10a00-1afe-11eb-9359-81cd400b8fe0.png" alt="image" style="max-width:100%;">
</details>

<details>
  <summary>After:</summary>
<img src="https://user-images.githubusercontent.com/580744/97761792-8fb5be00-1afe-11eb-92e4-33989ece83ad.png" alt="image" style="max-width:100%;">
</details>