### PR TITLE
Fixing README.md to fix changelog

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 ## Version history
 
-See [the changelog](CHANGELOG.md)
+See [the changelog](https://plugins.jenkins.io/pipeline-rest-api/#releases)
 
 # Stage View: 
 


### PR DESCRIPTION
Fixing README.md to fix changelog to actually point to a place where you can get updated release changelog information. Current link direction has not been updated in years. 

Issue: You click on "See the changelog" at https://plugins.jenkins.io/pipeline-rest-api/#documentation or on your github page and you get directed to a page that is no longer kept up to date.