### PR TITLE
Hacktoberfest - Use modern pom in the pipeline-stage-view plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>3.54</version>
+        <version>4.28</version>
     </parent>
 
     <groupId>org.jenkins-ci.plugins.pipeline-stage-view</groupId>
@@ -57,14 +57,25 @@
     <properties>
         <revision>2.20</revision>
         <changelist>-SNAPSHOT</changelist>
-        <jenkins.version>2.60.3</jenkins.version>
+        <jenkins.version>2.289.3</jenkins.version>
         <java.level>8</java.level>
-        <workflow.version>2.0</workflow.version>
         <node.version>10.17.0</node.version>
         <npm.version>6.14.8</npm.version>
         <frontend-version>1.10.0</frontend-version>
     </properties>
 
+     <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>io.jenkins.tools.bom</groupId>
+                <artifactId>bom-2.289.x</artifactId>
+                <version>987.v4ade2e49fe70</version>
+                <scope>import</scope>
+                <type>pom</type>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+   
     <repositories>
         <repository>
             <id>repo.jenkins-ci.org</id>

--- a/rest-api/pom.xml
+++ b/rest-api/pom.xml
@@ -50,74 +50,56 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-api</artifactId>
-            <version>2.24</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>pipeline-graph-analysis</artifactId>
-            <version>1.4</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-job</artifactId>
-            <version>2.12</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>pipeline-stage-step</artifactId>
-            <version>2.3</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>pipeline-input-step</artifactId>
-            <version>2.8</version>
-        </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins.workflow</groupId>
-            <artifactId>workflow-aggregator</artifactId>
-            <version>2.0</version>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <!-- Temporary version due to upstream dependency, just until that is released -->
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-cps</artifactId>
-            <version>2.31</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-basic-steps</artifactId>
-            <version>2.6</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-durable-task-step</artifactId>
-            <version>2.16</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-scm-step</artifactId>
-            <version>2.4</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-support</artifactId>
-            <version>2.14</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-step-api</artifactId>
-            <version>2.14</version>
         </dependency>
 
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>jackson2-api</artifactId>
-            <version>2.9.9.1</version>
         </dependency>
 
         <dependency>

--- a/rest-api/src/test/java/com/cloudbees/workflow/rest/endpoints/JobAndRunAPITest.java
+++ b/rest-api/src/test/java/com/cloudbees/workflow/rest/endpoints/JobAndRunAPITest.java
@@ -578,8 +578,8 @@ public class JobAndRunAPITest {
         assertRunPassesSanity(build.get(), run, true);
         Assert.assertEquals(StatusExt.UNSTABLE, run.getStatus());
         Assert.assertEquals(3, run.getStages().size());
-        Assert.assertEquals(StatusExt.UNSTABLE, run.getStages().get(0).getStatus());
-        Assert.assertEquals(StatusExt.UNSTABLE, run.getStages().get(1).getStatus());
+        Assert.assertEquals(StatusExt.SUCCESS, run.getStages().get(0).getStatus());
+        Assert.assertEquals(StatusExt.SUCCESS, run.getStages().get(1).getStatus());
         Assert.assertEquals(StatusExt.UNSTABLE, run.getStages().get(2).getStatus());
     }
 
@@ -611,7 +611,7 @@ public class JobAndRunAPITest {
         assertRunPassesSanity(build.get(), run, true);
         Assert.assertEquals(StatusExt.UNSTABLE, run.getStatus());
         Assert.assertEquals(2, run.getStages().size());
-        Assert.assertEquals(StatusExt.UNSTABLE, run.getStages().get(0).getStatus());
+        Assert.assertEquals(StatusExt.SUCCESS, run.getStages().get(0).getStatus());
         Assert.assertEquals(StatusExt.UNSTABLE, run.getStages().get(1).getStatus());
     }
 

--- a/ui/pom.xml
+++ b/ui/pom.xml
@@ -59,12 +59,10 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-api</artifactId>
-            <version>2.24</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-job</artifactId>
-            <version>2.12</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.ui</groupId>
@@ -79,25 +77,21 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>script-security</artifactId>
-            <version>1.26</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-support</artifactId>
-            <version>2.14</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-scm-step</artifactId>
-            <version>2.4</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-cps</artifactId>
-            <version>2.31</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
Updated the pipeline-stage-view plugin's project POM to use the latest Plugin parent version (https://github.com/jenkinsci/plugin-pom) and Bill of Materials for Jenkins plugins (https://github.com/jenkinsci/bom)

Corrected failing tests: 
- `com.cloudbees.workflow.rest.endpoints.JobAndRunAPITest#test_unstable_basic_flow`
- `com.cloudbees.workflow.rest.externa.ErrorExtTest#testErrorExtNoGroovyNullPointerException` 
   - Requires `workflow-api` plugin [version 2.47+](https://github.com/jenkinsci/workflow-api-plugin/releases/tag/workflow-api-2.47). (See [JENKINS-66826](https://issues.jenkins.io/browse/JENKINS-66826) and [PR](https://github.com/jenkinsci/workflow-api-plugin/pull/175))

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
