### PR TITLE
Routine updates (prereqs for jdk11 compatibility)

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        java: [8]
+        java: [8, 11]
       fail-fast: false
 
     runs-on: ${{ matrix.os }}

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,8 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>3.54</version>
+        <version>4.29</version>
+        <relativePath/>
     </parent>
 
     <groupId>org.jenkins-ci.plugins.pipeline-stage-view</groupId>
@@ -56,8 +57,9 @@
 
     <properties>
         <revision>2.20</revision>
+        <bom>2.204.x</bom>
+        <jenkins.version>2.204.6</jenkins.version>
         <changelist>-SNAPSHOT</changelist>
-        <jenkins.version>2.60.3</jenkins.version>
         <java.level>8</java.level>
         <workflow.version>2.0</workflow.version>
         <node.version>10.17.0</node.version>
@@ -93,4 +95,16 @@
             </plugin>
         </plugins>
     </build>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>io.jenkins.tools.bom</groupId>
+                <artifactId>bom-${bom}</artifactId>
+                <version>18</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 </project>

--- a/rest-api/pom.xml
+++ b/rest-api/pom.xml
@@ -29,7 +29,6 @@
         <groupId>org.jenkins-ci.plugins.pipeline-stage-view</groupId>
         <artifactId>parent-pom</artifactId>
         <version>${revision}${changelist}</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>pipeline-rest-api</artifactId>
@@ -50,7 +49,6 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-api</artifactId>
-            <version>2.24</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
@@ -60,17 +58,14 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-job</artifactId>
-            <version>2.12</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>pipeline-stage-step</artifactId>
-            <version>2.3</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>pipeline-input-step</artifactId>
-            <version>2.8</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
@@ -82,48 +77,40 @@
             <!-- Temporary version due to upstream dependency, just until that is released -->
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-cps</artifactId>
-            <version>2.31</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-basic-steps</artifactId>
-            <version>2.6</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-durable-task-step</artifactId>
-            <version>2.16</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-scm-step</artifactId>
-            <version>2.4</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-support</artifactId>
-            <version>2.14</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-step-api</artifactId>
-            <version>2.14</version>
         </dependency>
 
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>jackson2-api</artifactId>
-            <version>2.9.9.1</version>
         </dependency>
 
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>1.9.5</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>

--- a/rest-api/src/main/java/com/cloudbees/workflow/rest/external/FlowNodeLogExt.java
+++ b/rest-api/src/main/java/com/cloudbees/workflow/rest/external/FlowNodeLogExt.java
@@ -25,6 +25,7 @@ package com.cloudbees.workflow.rest.external;
 
 import com.cloudbees.workflow.util.ModelUtil;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.console.AnnotatedLargeText;
 import org.jenkinsci.plugins.workflow.actions.LogAction;
 import org.jenkinsci.plugins.workflow.graph.FlowNode;
@@ -99,6 +100,7 @@ public class FlowNodeLogExt {
         this.consoleUrl = consoleUrl;
     }
 
+    @SuppressFBWarnings(value = "RV_RETURN_VALUE_IGNORED", justification = "We're not writing to a file")
     public static FlowNodeLogExt create(FlowNode node) {
         FlowNodeLogExt logExt = new FlowNodeLogExt();
 

--- a/rest-api/src/test/java/com/cloudbees/workflow/rest/endpoints/ParallelStepTest.java
+++ b/rest-api/src/test/java/com/cloudbees/workflow/rest/endpoints/ParallelStepTest.java
@@ -141,14 +141,9 @@ public class ParallelStepTest {
         build.waitForStart();
 
         // Test while running
-        String jsonResponse = webClient.goTo(jobRunsUrl, "application/json").getWebResponse().getContentAsString();
-        RunExt[] runExts = new JSONReadWrite().fromString(jsonResponse, RunExt[].class);
-
-        Assert.assertEquals(1, runExts.length);
-        RunExt runExt = runExts[0];
+        RunExt runExt = getRunExt(jobRunsUrl);
         Assert.assertEquals(StatusExt.IN_PROGRESS, runExt.getStatus());
-
-        while (runExt.getStages().size()<4) {
+        while (runExt.getStages().size() < 4) {
             runExt = getRunExt(jobRunsUrl);
         }
 
@@ -160,11 +155,7 @@ public class ParallelStepTest {
         jenkinsRule.assertBuildStatusSuccess(build);
 
         // Test when completed
-        jsonResponse = webClient.goTo(jobRunsUrl, "application/json").getWebResponse().getContentAsString();
-        runExts = new JSONReadWrite().fromString(jsonResponse, RunExt[].class);
-
-        Assert.assertEquals(1, runExts.length);
-        runExt = runExts[0];
+        runExt = getRunExt(jobRunsUrl);
         Assert.assertEquals(StatusExt.SUCCESS, runExt.getStatus());
         Assert.assertEquals(5, runExt.getStages().size());
         Assert.assertEquals("SerialStartStage", runExt.getStages().get(0).getName());

--- a/rest-api/src/test/java/com/cloudbees/workflow/rest/external/ErrorExtTest.java
+++ b/rest-api/src/test/java/com/cloudbees/workflow/rest/external/ErrorExtTest.java
@@ -23,28 +23,12 @@
  */
 package com.cloudbees.workflow.rest.external;
 
-import groovy.lang.MissingPropertyException;
 import org.jenkinsci.plugins.workflow.actions.ErrorAction;
 import org.junit.Test;
 import static org.hamcrest.Matchers.containsString;
 import static org.junit.Assert.assertThat;
 
 public class ErrorExtTest {
-
-    /**
-     * This is a test against an issue which is fixed in Groovy 3.0 (GROOVY-8936) - It might start
-     * failing whenever groovy is updated to a version where this issue is fixed. See
-     * {@link #testErrorExtNoTestNullPointerException()} for a variant of this test against a broken
-     * local class.
-     */
-    @Test
-    public void testErrorExtNoGroovyNullPointerException() {
-        Throwable throwable = new MissingPropertyException(null);
-        ErrorAction errorAction = new ErrorAction(throwable);
-        ErrorExt errorExt = ErrorExt.create(errorAction);
-        assertThat(errorExt.getMessage(),
-                        containsString("No message: NullPointerException"));
-    }
 
     @Test
     public void testErrorExtNoTestNullPointerException() {

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -4759,7 +4759,7 @@
     "hbsfy": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/hbsfy/-/hbsfy-2.8.1.tgz",
-      "integrity": "sha512-NHn+bc1FI+TTZzFkpw+0JetPDzxRGiYBNMb3eSDO9J0rZE/SU6tm9QAc3JT9wblYOQWnGvzPENE+x+xDxlATeQ==",
+      "integrity": "sha1-Mwadz8r2pIGDUa6z1mT1ElkYCqk=",
       "dev": true,
       "requires": {
         "through": "~2.3.4",
@@ -8689,7 +8689,7 @@
         "tough-cookie": {
           "version": "2.5.0",
           "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
-          "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
+          "integrity": "sha1-zZ+yoKodWhK0c72fuW+j3P9lreI=",
           "dev": true,
           "requires": {
             "psl": "^1.1.28",

--- a/ui/pom.xml
+++ b/ui/pom.xml
@@ -29,7 +29,6 @@
         <groupId>org.jenkins-ci.plugins.pipeline-stage-view</groupId>
         <artifactId>parent-pom</artifactId>
         <version>${revision}${changelist}</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>pipeline-stage-view</artifactId>
@@ -59,12 +58,10 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-api</artifactId>
-            <version>2.24</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-job</artifactId>
-            <version>2.12</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.ui</groupId>
@@ -79,25 +76,21 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>script-security</artifactId>
-            <version>1.26</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-support</artifactId>
-            <version>2.14</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-scm-step</artifactId>
-            <version>2.4</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-cps</artifactId>
-            <version>2.31</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -113,6 +106,10 @@
                 <exclusion>
                     <groupId>org.apache.httpcomponents</groupId>
                     <artifactId>httpclient</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.mortbay.jetty</groupId>
+                    <artifactId>servlet-api-2.5</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>


### PR DESCRIPTION
* Update parent POM
* Bump Jenkins req to 2.204
* Use BOM
* Remove a broken test (introduced in https://github.com/jenkinsci/pipeline-stage-view-plugin/pull/81/)
* Exclude conflicting servlet-api jar

There is still one failed test with jdk11, can't understand what is going on at this point. Also sems to fail on java 8 after the dependencies update so I think there may be a real issue here.

```
[ERROR] com.cloudbees.workflow.rest.endpoints.ParallelStepTest.test_stages_order  Time elapsed: 2.068 s  <<< FAILURE!
java.lang.AssertionError: expected:<4> but was:<0>
        at org.junit.Assert.fail(Assert.java:89)
        at org.junit.Assert.failNotEquals(Assert.java:835)
        at org.junit.Assert.assertEquals(Assert.java:647)
        at org.junit.Assert.assertEquals(Assert.java:633)
        at com.cloudbees.workflow.rest.endpoints.ParallelStepTest.test_stages_order(ParallelStepTest.java:150)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
        at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.base/java.lang.reflect.Method.invoke(Method.java:566)
        at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:59)
        at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
        at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:56)
        at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
        at org.jvnet.hudson.test.JenkinsRule$1.evaluate(JenkinsRule.java:601)
        at org.junit.internal.runners.statements.FailOnTimeout$CallableStatement.call(FailOnTimeout.java:299)
        at org.junit.internal.runners.statements.FailOnTimeout$CallableStatement.call(FailOnTimeout.java:293)
        at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
        at java.base/java.lang.Thread.run(Thread.java:829)

```

<!-- Please describe your pull request here. -->

- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
