### PR TITLE
Let newer Jenkins versions override PNG icons

### DIFF
--- a/ui/src/main/java/com/cloudbees/workflow/ui/view/PluginImpl.java
+++ b/ui/src/main/java/com/cloudbees/workflow/ui/view/PluginImpl.java
@@ -38,8 +38,5 @@ public class PluginImpl extends Plugin {
     @Override
     public void start() throws Exception {
         super.start();
-
-        // Register the medium (24x24) icons...
-        IconSet.icons.addIcon(new Icon("icon-workflow-stage icon-md", "24x24/search.png", Icon.ICON_MEDIUM_STYLE));
     }
 }

--- a/ui/src/main/resources/com/cloudbees/workflow/ui/view/WorkflowStageViewAction/action.jelly
+++ b/ui/src/main/resources/com/cloudbees/workflow/ui/view/WorkflowStageViewAction/action.jelly
@@ -1,4 +1,4 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:l="/lib/layout">
-    <l:task href="${rootURL}/${action.target.url}${action.urlName}" icon="icon-workflow-stage icon-md" title="${action.displayName}"/>
+    <l:task href="${rootURL}/${action.target.url}${action.urlName}" icon="icon-search icon-md" title="${action.displayName}"/>
 </j:jelly>


### PR DESCRIPTION
This PR adds the ability to allow modern Jenkins versions to override PNGs with SVGs where applicable, in favor of core getting a rid of PNG icons in a foreseeable future: jenkinsci/jenkins#5778

Before:
![](https://i.imgur.com/d55SY50.png)

After:
![](https://i.imgur.com/Ycv7nsg.png)

- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [X] Ensure you have provided tests - that demonstrates feature works or fixes the issue