### PR TITLE
Prevent scrolling in modal window to scroll the body when reaching the end

### DIFF
--- a/ui/src/main/js/view/templates/stage-logs.less
+++ b/ui/src/main/js/view/templates/stage-logs.less
@@ -22,6 +22,7 @@
   .log-details {
     max-height: 400px;
     overflow: auto;
+    overscroll-behavior: contain;
     display: none;
     color:rgba(0,0,0,.67);
 


### PR DESCRIPTION
The modal window that can be opened by clicking on the _Logs_ button for some stage can be scrolled, but when reaching the end it will scroll the body as well, which makes it pretty annoying to get to the bottom of the logs quickly (scrolling fast will reach the bottom of the logs and then immediately scroll the modal window away, so you then need to scroll back up).
The `overscroll-behavior: contain;` CSS rule fixes this behavior by preventing the scrolling to go over to the parent when reaching the end (see https://developer.mozilla.org/en-US/docs/Web/CSS/overscroll-behavior).

Adding this rule manually through the Chrome webtools in a running Jenkins instance fixes the issue. I did not try to actually compile a local version of Jenkins, as I’m not sure how to do that (I only use Jenkins through my work) and it seems like a small enough fix that it is unlikely to cause issues.

Couldn’t find any other relevant issues/pull requests.
<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
