### PR TITLE
Fix link for build details

### DIFF
--- a/ui/src/main/java/com/cloudbees/workflow/ui/view/WorkflowStageViewAction.java
+++ b/ui/src/main/java/com/cloudbees/workflow/ui/view/WorkflowStageViewAction.java
@@ -33,7 +33,7 @@ public class WorkflowStageViewAction implements Action {
 
     @Override
     public String getUrlName() {
-        return "workflow-stage";
+        return "";
     }
 
     @Override


### PR DESCRIPTION
Not entirely sure, but I think this is responsible for https://issues.jenkins.io/browse/JENKINS-52385. The links behind the numbers (e.g. "#5508") at the left side of the Full Stage View are incorrect: They all have a sub-path ".../workflow-stage/..." that shouldn't be there. The links end up nowhere, with an HTTP 404 from stapler.