### PR TITLE
Revert text-shadow change until dark mode regression is fixed

### DIFF
--- a/ui/src/main/js/view/templates/pipeline-staged.less
+++ b/ui/src/main/js/view/templates/pipeline-staged.less
@@ -368,7 +368,6 @@
         box-shadow:0 0 0 1px rgba(0,0,0,.1);
         border-radius:4px;
         z-index: 2;
-        text-shadow: 1px 1px 3px rgba(256,256,256,0.5), -1px 2px 3px rgba(256,256,256,0.5), -1px -1px 3px rgba(256,256,256,0.5), 1px -1px 3px rgba(256,256,256,0.5);
       }
 
       .status {


### PR DESCRIPTION
Change introduced in #146 makes times near-unreadable in dark mode. Roll back the change until the regression is resolved.
@timbrown5 @tdspencer3
See https://github.com/jenkinsci/pipeline-stage-view-plugin/pull/146#issuecomment-1029704850

<!-- Please describe your pull request here. -->

- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
