### PR TITLE
Fix valueOf(Throwable t) function

### DIFF
--- a/rest-api/src/main/java/com/cloudbees/workflow/rest/external/StatusExt.java
+++ b/rest-api/src/main/java/com/cloudbees/workflow/rest/external/StatusExt.java
@@ -53,7 +53,8 @@ public enum StatusExt {
 
     public static StatusExt valueOf(Throwable t) {
         if (t instanceof FlowInterruptedException) {
-            return StatusExt.ABORTED;
+            FlowInterruptedException exception = (FlowInterruptedException) t;
+            return exception.isActualInterruption() ? StatusExt.ABORTED : StatusExt.FAILED;
         } else {
             return StatusExt.FAILED;
         }


### PR DESCRIPTION
Fix valueOf(Throwable t) function

some step(e.x build) failed throw FlowInterruptedException with  actualInterruption is false, so this moment is FAILED status rather than ABORTED