### PR TITLE
Fix for: Uncaught Required attribute 'objectUrl' not defined on MVC controller 'run-input-required' element.

### DIFF
--- a/ui/src/main/js/view/templates/pipeline-staged.hbs
+++ b/ui/src/main/js/view/templates/pipeline-staged.hbs
@@ -92,7 +92,7 @@
                     <div cbwf-controller="stage-actions-popover" descUrl="{{this._links.self.href}}" notIf="stage-actions-popover,stage-failed-popover" caption="Unstable Build"></div>
                 {{/ifCond}}
                 {{#ifCond this.status '===' 'PAUSED_PENDING_INPUT'}}
-                    <div cbwf-controller="run-input-required" objectUrl="{{../../_links.nextPendingInputAction.href}}"></div>
+                    <div cbwf-controller="run-input-required" objectUrl="{{../_links.nextPendingInputAction.href}}"></div>
                     <div class="status">paused</div>
                 {{/ifCond}}
                 {{#ifCond this.status '===' 'FAILED'}}


### PR DESCRIPTION
After updating everything to the latest versions on our Jenkins instance I noticed that the stage-view no longer appeared if there was a pipeline waiting for input.
The console displayed following error:
`Uncaught Required attribute 'objectUrl' not defined on MVC controller 'run-input-required' element.`

Debugging revealed that the reference in [`/ui/src/main/js/view/templates/pipeline-staged.hbs`](https://github.com/jenkinsci/pipeline-stage-view-plugin/blob/master/ui/src/main/js/view/templates/pipeline-staged.hbs) to fetch the PendingInputAction href was no longer valid:
```js
                {{#ifCond this.status '===' 'PAUSED_PENDING_INPUT'}}
                    <div cbwf-controller="run-input-required" objectUrl="{{../../_links.nextPendingInputAction.href}}"></div>
                    <div class="status">paused</div>
                {{/ifCond}}
```

I'm not sure why `{{../../_links.nextPendingInputAction.href}}` no longer works but `{{../_links.nextPendingInputAction.href}}` does.
We might need a conditional check if this has anything to do with interfering plugins and / or a specific jenkins version. 

- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
