### PR TITLE
Use HTTPS SCM URL

### DIFF
--- a/rest-api/pom.xml
+++ b/rest-api/pom.xml
@@ -39,7 +39,7 @@
     <packaging>hpi</packaging>
 
     <scm>
-       <connection>scm:git:git://github.com/jenkinsci/pipeline-stage-view-plugin.git</connection>
+       <connection>scm:git:https://github.com/jenkinsci/pipeline-stage-view-plugin.git</connection>
        <developerConnection>scm:git:git@github.com:jenkinsci/pipeline-stage-view-plugin.git</developerConnection>
        <url>https://github.com/jenkinsci/pipeline-stage-view-plugin</url>
        <tag>${scmTag}</tag>

--- a/ui/pom.xml
+++ b/ui/pom.xml
@@ -43,7 +43,7 @@
     </properties>
 
     <scm>
-       <connection>scm:git:git://github.com/jenkinsci/pipeline-stage-view-plugin.git</connection>
+       <connection>scm:git:https://github.com/jenkinsci/pipeline-stage-view-plugin.git</connection>
        <developerConnection>scm:git:git@github.com:jenkinsci/pipeline-stage-view-plugin.git</developerConnection>
        <url>https://github.com/jenkinsci/pipeline-stage-view-plugin</url>
        <tag>${scmTag}</tag>


### PR DESCRIPTION
The old protocol is [deprecated](https://github.blog/2021-09-01-improving-git-protocol-security-github/).