### PR TITLE
PCT compatibility with GitHub plugin

### DIFF
--- a/ui/pom.xml
+++ b/ui/pom.xml
@@ -65,6 +65,11 @@
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>bouncycastle-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>script-security</artifactId>
             <scope>test</scope>
         </dependency>
@@ -89,6 +94,15 @@
             <version>1.1.0</version>
             <scope>test</scope>
             <exclusions>
+                <!-- Provided by bouncycastle-api plugin -->
+                <exclusion>
+                    <groupId>org.bouncycastle</groupId>
+                    <artifactId>bcpkix-jdk15on</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.bouncycastle</groupId>
+                    <artifactId>bcprov-jdk15on</artifactId>
+                </exclusion>
                 <exclusion>
                     <groupId>org.seleniumhq.selenium</groupId>
                     <artifactId>selenium-java</artifactId>


### PR DESCRIPTION
Observed the following PCT error when trying to add the `github` plugin to `jenkinsci/bom`:

```
SEVERE: Failed Loading plugin bouncycastle API Plugin v2.27 (bouncycastle-api)
java.io.IOException: Failed to initialize
        at hudson.ClassicPluginStrategy.load(ClassicPluginStrategy.java:409)
        at hudson.PluginManager$2$1$1.run(PluginManager.java:551)
        at org.jvnet.hudson.reactor.TaskGraphBuilder$TaskImpl.run(TaskGraphBuilder.java:177)
        at org.jvnet.hudson.reactor.Reactor.runTask(Reactor.java:305)
        at jenkins.model.Jenkins$5.runTask(Jenkins.java:1164)
        at org.jvnet.hudson.reactor.Reactor$2.run(Reactor.java:221)
        at org.jvnet.hudson.reactor.Reactor$Node.run(Reactor.java:120)
        at jenkins.security.ImpersonatingExecutorService$1.run(ImpersonatingExecutorService.java:68)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
        at java.base/java.lang.Thread.run(Thread.java:833)
Caused by: java.lang.SecurityException: class "org.bouncycastle.jcajce.provider.symmetric.IDEA$Mappings"'s signer information does not match signer information of other classes in the same package
        at java.base/java.lang.ClassLoader.checkCerts(ClassLoader.java:1158)
        at java.base/java.lang.ClassLoader.preDefineClass(ClassLoader.java:902)
        at java.base/java.lang.ClassLoader.defineClass(ClassLoader.java:1010)
        at java.base/java.security.SecureClassLoader.defineClass(SecureClassLoader.java:150)
        at java.base/jdk.internal.loader.BuiltinClassLoader.defineClass(BuiltinClassLoader.java:862)
        at java.base/jdk.internal.loader.BuiltinClassLoader.findClassOnClassPathOrNull(BuiltinClassLoader.java:760)
        at java.base/jdk.internal.loader.BuiltinClassLoader.loadClassOrNull(BuiltinClassLoader.java:681)
        at java.base/jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:639)
        at java.base/jdk.internal.loader.ClassLoaders$AppClassLoader.loadClass(ClassLoaders.java:188)
        at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:520)
        at org.bouncycastle.jce.provider.BouncyCastleProvider.loadAlgorithms(Unknown Source)
        at org.bouncycastle.jce.provider.BouncyCastleProvider.setup(Unknown Source)
        at org.bouncycastle.jce.provider.BouncyCastleProvider.access$000(Unknown Source)
        at org.bouncycastle.jce.provider.BouncyCastleProvider$1.run(Unknown Source)
        at java.base/java.security.AccessController.doPrivileged(AccessController.java:318)
        at org.bouncycastle.jce.provider.BouncyCastleProvider.<init>(Unknown Source)
        at jenkins.bouncycastle.api.BcProviderRegistration.register(BcProviderRegistration.java:42)
        at jenkins.bouncycastle.api.BcProviderRegistration.register(BcProviderRegistration.java:28)
        at jenkins.bouncycastle.api.SecurityProviderInitializer.addSecurityProvider(SecurityProviderInitializer.java:50)
        at jenkins.bouncycastle.api.BouncyCastlePlugin.start(BouncyCastlePlugin.java:62)
        at hudson.ClassicPluginStrategy.startPlugin(ClassicPluginStrategy.java:417)
        at hudson.ClassicPluginStrategy.load(ClassicPluginStrategy.java:406)
        ... 10 more
```

This is due to a conflict between the Bouncy Castle provided on the test class path and that pulled in transitively via GitHub plugin's dependency on Instance Identity. With this fix I verified that the problem no longer occurs.