### PR TITLE
[JENKINS-63115] Fix Stage View display issues due to stage ordering

### DIFF
--- a/rest-api/src/main/java/com/cloudbees/workflow/rest/endpoints/JobAPI.java
+++ b/rest-api/src/main/java/com/cloudbees/workflow/rest/endpoints/JobAPI.java
@@ -29,6 +29,7 @@ import com.cloudbees.workflow.rest.external.RunExt;
 import com.cloudbees.workflow.util.ModelUtil;
 import com.cloudbees.workflow.util.ServeJson;
 import hudson.Extension;
+import hudson.model.Result;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.kohsuke.stapler.QueryParameter;
 
@@ -67,6 +68,7 @@ public class JobAPI extends AbstractWorkflowJobActionHandler {
     @ServeJson
     public List<RunExt> doRuns(@QueryParameter String since, @QueryParameter boolean fullStages) {
         return JobExt.create(getJob().getBuilds(), since, fullStages);
+//        return JobExt.create(getJob().getLastBuildsOverThreshold(10, Result.ABORTED), since, fullStages);
     }
 
     @ServeJson


### PR DESCRIPTION
There was a well known issue that stage view may only show the last run in progress when there are run in progress. And then will show other runs once completed. This is often the case for parallel executions that does not guarantee that stages be executed in a particular order.

A fix that was made to allow displaying several runs in the stage view **when there are runs in progress**. This was done by ordering the stages returned by the backend end by start time https://github.com/jenkinsci/pipeline-stage-view-plugin/pull/88.

This however caused another issues. The stage view of a pipeline that has all its stages completed does not show runs previous runs if there is a difference in the new ordering of stages.. Based on stage start execution time..

This ordering done in the backend seems quite inconsistent and arbitraty. Going through the code, the front end is actually making decision based on stages ordering https://github.com/jenkinsci/pipeline-stage-view-plugin/blob/pipeline-stage-view-2.32/ui/src/main/js/model/runs-stage-grouped.js#L263-L281.

I believe a better fix for both cases is to relax the stage ordering rule in case of in progress runs while keeping it for completed runs.

- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue