### PR TITLE
Replace Prototype.js with native JavaScript

### DIFF
--- a/ui/src/main/js/util/ajax.js
+++ b/ui/src/main/js/util/ajax.js
@@ -39,10 +39,12 @@ exports.execAsyncGET = function (resPathTokens, success, params) {
 };
 
 exports.jenkinsAjaxGET = function (path, success) {
-    new Ajax.Request(path, {
-        method : 'get',
-        cache: false, // Force caching off for IE (and anything else)
-        onSuccess: success
+    fetch(path, {
+        cache: 'no-cache', // Force caching off for IE (and anything else)
+    }).then((rsp) => {
+        if (rsp.ok) {
+            success();
+        }
     });
 };
 
@@ -52,30 +54,46 @@ exports.jenkinsAjaxPOST = function () {
         var data = arguments[1];
         var success = arguments[2];
         if (typeof data !== 'string') {
-            data = Object.toJSON(data);
+            // TODO simplify when Prototype.js is removed
+            data = Object.toJSON ? Object.toJSON(data) : JSON.stringify(data);
         }
-        new Ajax.Request(path, {
-            contentType: "application/json",
-            encoding: "UTF-8",
-            postBody: data,
-            onSuccess: success
+        fetch(path, {
+            method: 'post',
+            headers: crumb.wrap({
+                'Content-Type': 'application/json; charset=UTF-8'
+            }),
+            body: data,
+        }).then((rsp) => {
+            if (rsp.ok) {
+                success();
+            }
         });
     } else {
         var success = arguments[1];
-        new Ajax.Request(path, {
-            contentType: "application/json",
-            method : 'post',
-            onSuccess: success
+        fetch(path, {
+            method: 'post',
+            headers: crumb.wrap({
+                'Content-Type': 'application/json'
+            }),
+        }).then((rsp) => {
+            if (rsp.ok) {
+                success();
+            }
         });
     }
 };
 
 
 exports.jenkinsAjaxPOSTURLEncoded = function (path, parameters, success) {
-    new Ajax.Request(path, {
-        method : 'post',
-        contentType: "application/x-www-form-urlencoded",
-        parameters: parameters,
-        onSuccess: success
+    fetch(path, {
+        method: 'post',
+        headers: crumb.wrap({
+            'Content-Type': 'application/x-www-form-urlencoded'
+        }),
+        body: new URLSearchParams(parameters),
+    }).then((rsp) => {
+        if (rsp.ok) {
+            success();
+        }
     });
 }

--- a/ui/src/main/js/view/run-input-required.js
+++ b/ui/src/main/js/view/run-input-required.js
@@ -96,10 +96,9 @@ exports.render = function (inputRequiredModel, onElement) {
 
                     // Perform the POST. Needs to be encoded into a "json" parameter with an
                     // array object named "parameter" :)
+                    // TODO simplify when Prototype.js is removed
                     var parameters = {
-                        json: Object.toJSON({
-                            parameter: inputNVPs
-                        })
+                        json: Object.toJSON ? Object.toJSON({ parameter: inputNVPs }) : JSON.stringify({ parameter: inputNVPs })
                     };
                     ajax.jenkinsAjaxPOSTURLEncoded(proceedUrl, parameters, function() {
                         popover.hide();


### PR DESCRIPTION
See [JENKINS-70906](https://issues.jenkins.io/browse/JENKINS-70906). Jenkins core currently uses [Prototype 1.7](https://github.com/prototypejs/prototype/releases/tag/1.7), released on November 15, 2010. The latest version is [Prototype 1.7.3](https://github.com/prototypejs/prototype/releases/tag/1.7.3), released on September 22, 2015. When an attempt was made to upgrade to 1.7.3 in 2018 in [JENKINS-49319](https://issues.jenkins.io/browse/JENKINS-49319), the change had to be reverted. Since this library has been unmaintained for the past 8 years, this PR removes any usages of it in favor of native JavaScript APIs. To test this, I enabled the user experimental flag to remove Prototype on 2.404 and started a Pipeline job with an input step. I verified that approving the input step failed prior to this PR and passed with this PR, stepping through the relevant code in the debugger to verify that the changed lines were being executed.