### PR TITLE
Un-inline js from controller.jelly

### DIFF
--- a/ui/src/main/resources/com/cloudbees/workflow/controller.jelly
+++ b/ui/src/main/resources/com/cloudbees/workflow/controller.jelly
@@ -9,7 +9,7 @@
             Optional fragment caption, passed through to the controller.
         </st:attribute>
     </st:documentation>
-    <script>var timeZone = '${it.timeZone}';</script>
+    <st:adjunct includes="com.cloudbees.workflow.controller"/>
     <div class="cbwf-stage-view">
         <div cbwf-controller="${name}" objectUrl="${rootURL}/${it.target.url}" fragCaption="${fragCaption}" />
         <st:adjunct includes="org.jenkinsci.pipeline.stageview_adjunct"/>

--- a/ui/src/main/resources/com/cloudbees/workflow/controller.js
+++ b/ui/src/main/resources/com/cloudbees/workflow/controller.js
@@ -1,0 +1,1 @@
+var timeZone = '${it.timeZone}'


### PR DESCRIPTION
This PR aims to un-inline the script in controller.jelly

Target issue: [JIRA LINK](https://issues.jenkins.io/browse/JENKINS-72137?jql=labels%20%3D%20newbie-friendly%20and%20status%20in%20(Open%2C%20"To%20Do"%2C%20Reopened))

### Testing done
mvn hpi:run works fine on 8080


### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
