### PR TITLE
feat:Remove inline javascript code from Cloudbees workflow

### DIFF
--- a/ui/src/main/resources/com/cloudbees/workflow/controller.jelly
+++ b/ui/src/main/resources/com/cloudbees/workflow/controller.jelly
@@ -9,7 +9,7 @@
             Optional fragment caption, passed through to the controller.
         </st:attribute>
     </st:documentation>
-    <div id = 'timeparam' data-time = '${it.timeZone}'/>
+    <div id='timeparam' data-time='${it.timeZone}'/>
     <st:adjunct includes="com.cloudbees.workflow.controllerScript"/>
     <div class="cbwf-stage-view">
         <div cbwf-controller="${name}" objectUrl="${rootURL}/${it.target.url}" fragCaption="${fragCaption}" />

--- a/ui/src/main/resources/com/cloudbees/workflow/controller.jelly
+++ b/ui/src/main/resources/com/cloudbees/workflow/controller.jelly
@@ -9,7 +9,8 @@
             Optional fragment caption, passed through to the controller.
         </st:attribute>
     </st:documentation>
-    <script>var timeZone = '${it.timeZone}';</script>
+    <div id = 'timeparam' data-time = '${it.timeZone}'/>
+    <st:adjunct includes="com.cloudbees.workflow.controllerScript"/>
     <div class="cbwf-stage-view">
         <div cbwf-controller="${name}" objectUrl="${rootURL}/${it.target.url}" fragCaption="${fragCaption}" />
         <st:adjunct includes="org.jenkinsci.pipeline.stageview_adjunct"/>

--- a/ui/src/main/resources/com/cloudbees/workflow/controllerScript.js
+++ b/ui/src/main/resources/com/cloudbees/workflow/controllerScript.js
@@ -1,0 +1,1 @@
+var timeZone = document.querySelector('#timeparam').dataset.time;


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

### Testing done
Maven tests pass and mvn hpi:run does not reveal time zone anymore.
<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```
Converted inline script to recommended approach as mentioned in https://www.jenkins.io/doc/developer/security/csp/#inline-javascript-blocks .
Issue: https://issues.jenkins.io/browse/JENKINS-72137
<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
