### PR TITLE
Cap `runCount` in unused `JobApi.doDescribe`

### DIFF
--- a/rest-api/src/main/java/com/cloudbees/workflow/rest/external/JobExt.java
+++ b/rest-api/src/main/java/com/cloudbees/workflow/rest/external/JobExt.java
@@ -102,12 +102,17 @@ public class JobExt {
     }
 
     private static int countRuns(WorkflowJob job) {
+        int maxRunsPerJob = Integer.getInteger(MAX_RUNS_PER_JOB_PROPERTY_NAME, MAX_RUNS_PER_JOB_DEFAULT);
+
         int count = 0;
 
-        // RunList.size() is deprecated, so iterating to count them.
+        // RunList.size() is deprecated *for a good reason*, so iterating to count them.
         RunList<WorkflowRun> runs = job.getBuilds();
         for (WorkflowRun run : runs) {
             count++;
+            if (count >= maxRunsPerJob) {
+                break;
+            }
         }
 
         return count;


### PR DESCRIPTION
This REST API method is not used by the stage view GUI, but if anyone did in fact call this endpoint, it would load every build into memory, potentially wrecking controller performance. Forgotten in #14 and I guess earlier & later changes in the same area.