### PR TITLE
Fix pipeline box overflow with scroll

### DIFF
--- a/ui/src/main/js/view/templates/pipeline-staged.less
+++ b/ui/src/main/js/view/templates/pipeline-staged.less
@@ -129,6 +129,7 @@
       display: inline-block;
       border: 1px solid #ccc;
       border: 1px solid var(--panel-border-color);
+      width: 100%;
       overflow-x: auto;
       overflow-y: hidden;
       box-shadow: rgba(0, 0, 0, .25) 1px 3px 5px;

--- a/ui/src/main/less/stageview.less
+++ b/ui/src/main/less/stageview.less
@@ -1,6 +1,7 @@
 // The main container for CBWF Stage View
 .cbwf-stage-view {
   padding: 15px 0;
+  width: 100%;
   clear: right;
   display: inline-block;
 }


### PR DESCRIPTION
Stage View overflow breaks when the number of stages does not fit the viewport width. This PR fixes the overflow behaviour for the "Stage View" by allowing the scroll.

### Testing done

Tested this on various screens of different viewport.

### Submitter checklist
- [ x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x ] Please describe what you did
- [] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [] Ensure you have provided tests - that demonstrates feature works or fixes the issue

