### PR TITLE
Jenkins 73817 Add a Configuration Parameter to Control Log Output Format (Text vs. HTML)

### DIFF
--- a/rest-api/src/main/java/com/cloudbees/workflow/rest/endpoints/FlowNodeAPI.java
+++ b/rest-api/src/main/java/com/cloudbees/workflow/rest/endpoints/FlowNodeAPI.java
@@ -30,6 +30,7 @@ import com.cloudbees.workflow.util.ModelUtil;
 import com.cloudbees.workflow.util.ServeJson;
 import hudson.Extension;
 import org.jenkinsci.plugins.workflow.graph.FlowNode;
+import org.kohsuke.stapler.QueryParameter;
 
 import java.io.IOException;
 
@@ -59,7 +60,8 @@ public class FlowNodeAPI extends AbstractFlowNodeActionHandler {
     }
 
     @ServeJson
-    public Object doLog() {
-        return Log.get(getNode());
+    public Object doLog(@QueryParameter boolean text) {
+        System.out.println("doLog:text:"+text);
+        return text?Log.getText(getNode()):Log.getHtmlText(getNode());
     }
 }

--- a/rest-api/src/main/java/com/cloudbees/workflow/rest/endpoints/FlowNodeAPI.java
+++ b/rest-api/src/main/java/com/cloudbees/workflow/rest/endpoints/FlowNodeAPI.java
@@ -61,7 +61,6 @@ public class FlowNodeAPI extends AbstractFlowNodeActionHandler {
 
     @ServeJson
     public Object doLog(@QueryParameter boolean text) {
-        System.out.println("doLog:text:"+text);
         return text?Log.getText(getNode()):Log.getHtmlText(getNode());
     }
 }

--- a/rest-api/src/main/java/com/cloudbees/workflow/rest/endpoints/flownode/Log.java
+++ b/rest-api/src/main/java/com/cloudbees/workflow/rest/endpoints/flownode/Log.java
@@ -37,7 +37,11 @@ public class Log {
         return FlowNodeAPI.getUrl(node) + "/log";
     }
 
-    public static FlowNodeLogExt get(FlowNode node) {
-        return FlowNodeLogExt.create(node);
+    public static FlowNodeLogExt getText(FlowNode node) {
+        return FlowNodeLogExt.createText(node);
+    }
+
+    public static FlowNodeLogExt getHtmlText(FlowNode node) {
+        return FlowNodeLogExt.createHtmlText(node);
     }
 }

--- a/rest-api/src/main/java/com/cloudbees/workflow/rest/external/FlowNodeLogExt.java
+++ b/rest-api/src/main/java/com/cloudbees/workflow/rest/external/FlowNodeLogExt.java
@@ -132,13 +132,14 @@ public class FlowNodeLogExt {
 
                 if (logLen > 0) {
                     try {
+                        StringWriter write = new StringWriter();
+                        long endLog;
                         if (text) {
-                            ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
-                            logText.writeRawLogTo(logLen - logExt.getLength(), byteArrayOutputStream);
-                            logExt.setText(byteArrayOutputStream.toString(StandardCharsets.UTF_8));
+                            endLog = logText.writeLogTo(logLen - logExt.getLength(), write);
                         } else {
-                            StringWriter write = new StringWriter();
-                            logText.writeHtmlTo(logLen - logExt.getLength(), write);
+                            endLog = logText.writeHtmlTo(logLen - logExt.getLength(), write);
+                        }
+                        if(endLog == logExt.getLength() ){
                             logExt.setText(write.toString());
                         }
 


### PR DESCRIPTION
Currently, our logging system does not provide a direct way to switch between pure text and HTML-formatted log outputs. This limitation can be restrictive in scenarios where logs need to be rendered directly in web interfaces or where specific formatting requirements (e.g., for highlighting, linking, or styling) are desired.

To enhance the flexibility and usability of our logging capabilities, I propose the addition of a new configuration parameter that would allow users to specify the desired output format for logs. This parameter could be easily integrated into our existing logging framework, allowing for seamless transitions between text and HTML modes as needed.




Example:

http://{ip_host}/job/{optionalFolderPath}/job/{job_name}/{build_number}/execution/node/{nodeId}/wfapi/log?text=true