### PR TITLE
Simplify JSON usages; update baseline to 2.426.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,8 +58,9 @@
     <properties>
         <revision>2.35</revision>
         <gitHubRepo>jenkinsci/pipeline-stage-view-plugin</gitHubRepo>
-        <bom>2.361.x</bom>
-        <jenkins.version>2.361.4</jenkins.version>
+        <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
+        <jenkins.baseline>2.426</jenkins.baseline>
+        <jenkins.version>${jenkins.baseline}.3</jenkins.version>
         <changelist>-SNAPSHOT</changelist>
         <node.version>18.7.0</node.version>
         <npm.version>8.15.0</npm.version>
@@ -98,20 +99,10 @@
         <dependencies>
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
-                <artifactId>bom-${bom}</artifactId>
-                <version>2102.v854b_fec19c92</version>
+                <artifactId>bom-${jenkins.baseline}.x</artifactId>
+                <version>3208.vb_21177d4b_cd9</version>
                 <type>pom</type>
                 <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.json</groupId>
-                <artifactId>json</artifactId>
-                <version>20230618</version>
-            </dependency>
-            <dependency>
-                <groupId>org.yaml</groupId>
-                <artifactId>snakeyaml</artifactId>
-                <version>1.33</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/ui/src/main/js/util/ajax.js
+++ b/ui/src/main/js/util/ajax.js
@@ -54,8 +54,7 @@ exports.jenkinsAjaxPOST = function () {
         var data = arguments[1];
         var success = arguments[2];
         if (typeof data !== 'string') {
-            // TODO simplify when Prototype.js is removed
-            data = Object.toJSON ? Object.toJSON(data) : JSON.stringify(data);
+            data = JSON.stringify(data);
         }
         fetch(path, {
             method: 'post',

--- a/ui/src/main/js/view/run-input-required.js
+++ b/ui/src/main/js/view/run-input-required.js
@@ -96,9 +96,8 @@ exports.render = function (inputRequiredModel, onElement) {
 
                     // Perform the POST. Needs to be encoded into a "json" parameter with an
                     // array object named "parameter" :)
-                    // TODO simplify when Prototype.js is removed
                     var parameters = {
-                        json: Object.toJSON ? Object.toJSON({ parameter: inputNVPs }) : JSON.stringify({ parameter: inputNVPs })
+                        json: JSON.stringify({ parameter: inputNVPs })
                     };
                     ajax.jenkinsAjaxPOSTURLEncoded(proceedUrl, parameters, function() {
                         popover.hide();

--- a/ui/src/test/js/helper.js
+++ b/ui/src/test/js/helper.js
@@ -26,10 +26,6 @@ var log = require('fancy-log');
 var fs = require('fs');
 var requireUncached = require("require-uncached");
 
-Object.toJSON = function(object) {
-    return JSON.stringify(object);
-}
-
 /**
  * require one of the pipeline source modules.
  * <p/>


### PR DESCRIPTION
Now that Prototype.js has been removed in 2.426.x, we can remove the no-longer needed `Object.toJSON` workaround. This PR therefore updates this plugin's baseline to 2.426.3.