### PR TITLE
Fix pipeline box overflow with scroll

### DIFF
--- a/ui/src/main/js/view/templates/pipeline-staged.less
+++ b/ui/src/main/js/view/templates/pipeline-staged.less
@@ -23,6 +23,10 @@
 #pipeline-box {
   position: relative;
   box-sizing: border-box;
+  display: inline-block;
+  width: 100%;
+  padding: 15px 0;
+  overflow: auto;
 
   .extension-dock {
     font-size: 11px;

--- a/ui/src/main/less/stageview.less
+++ b/ui/src/main/less/stageview.less
@@ -1,8 +1,7 @@
 // The main container for CBWF Stage View
 .cbwf-stage-view {
-  padding: 15px 0;
   clear: right;
-  display: inline-block;
+  display: inline;
 }
 
 // Selectively import some twitter bootstrap styles.  Namespace them too.


### PR DESCRIPTION
This change set back the possibility to have scroll on multi stage pipeline. Moving the display to inline and the child in inline block allow to have the padding

### Testing done

Use javascript tools console to find a way to have  scrollbar and not go outside the box