### PR TITLE
Fix pipeline box overflow with scroll

### DIFF
--- a/ui/src/main/js/view/templates/pipeline-staged.less
+++ b/ui/src/main/js/view/templates/pipeline-staged.less
@@ -23,6 +23,8 @@
 #pipeline-box {
   position: relative;
   box-sizing: border-box;
+  display: inline;
+  overflow: auto;
 
   .extension-dock {
     font-size: 11px;

--- a/ui/src/main/less/stageview.less
+++ b/ui/src/main/less/stageview.less
@@ -1,8 +1,7 @@
 // The main container for CBWF Stage View
 .cbwf-stage-view {
-  padding: 15px 0;
   clear: right;
-  display: inline-block;
+  overflow: auto;
 }
 
 // Selectively import some twitter bootstrap styles.  Namespace them too.


### PR DESCRIPTION
This change set back the possibility to have scroll on multi stage pipeline. Moving the display to inline

The only way I found to have the correct behavior is to use display inline but I lost the padding part of 15px