### PR TITLE
JENKINS-75271 Pipeline start time and changes data cells are improper…

### DIFF
--- a/ui/src/main/js/view/templates/pipeline-staged.less
+++ b/ui/src/main/js/view/templates/pipeline-staged.less
@@ -226,6 +226,7 @@
             background: var(--background);
             position: relative;
             z-index: 2;
+            min-height: 4em;
           }
 
           .jobName {


### PR DESCRIPTION
Bugfix [JENKINS-75271](https://issues.jenkins.io/browse/JENKINS-75271) Pipeline start time and changes data cells are improperly displayed
The height of .changeset-box is the same with .stage-start-box. 
By removing the date and year if today which is introduced in [this commit](https://github.com/jenkinsci/pipeline-stage-view-plugin/commit/5c5b88011ae9cc166edaf978f1a3f49586add9d5), the height of .stage-start-box is not enough to display the content of changeset. 
This fix introduces a min-height of 4em to ensure the height.

### Testing done
![screenshot before fix](https://github.com/user-attachments/assets/79a07bc7-3a66-4f2b-ba36-0f944c6f595e)
![screenshot after fix](https://github.com/user-attachments/assets/d941d1fd-245c-4e06-bb58-3ded24897756)


### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
