### PR TITLE
Allow to disable Stage View in the main job page through system property

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,3 +110,23 @@ expected to take, based on historical averages.
         note: this may have a very large performance impact with complex
         builds.
 
+-   At runtime or startup, you may disable showing the Stage View within the
+    main job page with the property
+     `org.jenkinsci.pipeline.stageview.disabledOnMainJobPage`
+
+    -   This may help with performance issues by avoiding to load stage details
+        whenever the job page is loaded. The Stage View can still be accessed
+        from the left menu, through the _Full Stage View_ link.
+
+    -   In the script console this setting may be changed at runtime
+        (with immediate impact):
+
+        ``` syntaxhighlighter-pre
+        System.setProperty("org.jenkinsci.pipeline.stageview.disabledOnMainJobPage","true");
+        ```
+
+    -   To turn it back on:
+
+        ``` syntaxhighlighter-pre
+        System.clearProperty("org.jenkinsci.pipeline.stageview.disabledOnMainJobPage");
+        ```

--- a/ui/src/main/resources/com/cloudbees/workflow/ui/view/WorkflowStageViewAction/jobMain.jelly
+++ b/ui/src/main/resources/com/cloudbees/workflow/ui/view/WorkflowStageViewAction/jobMain.jelly
@@ -5,5 +5,7 @@
     It loads jobMain.jelly for all Action impls bound to a WorkflowJob.
 -->
 <j:jelly xmlns:j="jelly:core" xmlns:wf="/com/cloudbees/workflow">
-    <wf:controller name="pipeline-staged" fragCaption="${%Stage View}" />
+    <j:if test="${h.getSystemProperty('org.jenkinsci.pipeline.stageview.disabledOnMainJobPage') != 'true'}">
+        <wf:controller name="pipeline-staged" fragCaption="${%Stage View}" />
+    </j:if>
 </j:jelly>


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

I have some really big jobs and my Jenkins server is running slow. Upon investigation, I noticed that Jenkins spends a lot of time processing API requests from this plugin.

While the Stage View information is very useful, I do not need it to be opened automatically when I open a job. There is a _Full Stage View_ button in the job page that I can click if I want to see it.

This PR allows to disable the automatic opening of the Stage View when a job is opened. This is done by adding a new system property `org.jenkinsci.pipeline.stageview.disabledOnMainJobPage` as `true`. If not set, it behaves as before.

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

Works great in my local tests.

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
