### PR TITLE
[JENKINS-35656] Use Jenkins user timezone or browser timezone for stage view

### DIFF
--- a/ui/README.md
+++ b/ui/README.md
@@ -154,11 +154,11 @@ So far we've ben writing two types of tests for the UI components:
 
 1. JavaScript based unit tests for testing the JavaScript components.  These tests are more lightweight and should run more quickly (no Jenkins instance, no browser env).
 Please see the [JavaScript Testing][js_testing] docs.
-1. More coarse grained Java based function tests using a combination of [`JenkinsRule`][JenkinsRule] and [PhantomJS] (headless browser)
-e.g. [`WorkflowJobActionTest`][WorkflowJobActionTest].  Extend [`AbstractPhantomJSTest`][AbstractPhantomJSTest] for these types of test.
-[`JenkinsRule`][JenkinsRule] allows us to create pipelines in a Jenkins instance embedded in the test, while [PhantomJS] allows us to
+1. More coarse grained Java based function tests using a combination of [`JenkinsRule`][JenkinsRule] and [WebDriver] (headless browser)
+e.g. [`WorkflowJobActionTest`][WorkflowJobActionTest].  Extend [`AbstractWebDriverTest`][AbstractWebDriverTest] for these types of test.
+[`JenkinsRule`][JenkinsRule] allows us to create pipelines in a Jenkins instance embedded in the test, while [WebDriver] allows us to
 request the relevant pages to be tested from that Jenkins instance.
-    * Note you must have PhantomJS [installed on your local machine](http://phantomjs.org/download.html).  We might look at using [phantomjs-maven-plugin](https://github.com/klieber/phantomjs-maven-plugin).
+    * Note you must have Chrome [installed on your local machine](https://chromium.googlesource.com/chromium/src/+/lkgr/headless/README.md).
     * Note you can also use the [`WebClient`][WebClient] to mimic web interactions, but you might find it to be a headache with respect
     to it being overly picky about JavaScript (raising variable resolution failures etc not seen on any real browser).
 
@@ -173,10 +173,10 @@ request the relevant pages to be tested from that Jenkins instance.
 [nodejs]: http://nodejs.org/
 [CommonJS]: http://wiki.commonjs.org/wiki/CommonJS
 [JenkinsRule]: http://javadoc.jenkins-ci.org/org/jvnet/hudson/test/JenkinsRule.html
-[PhantomJS]: http://phantomjs.org/
+[WebDriver]: https://www.selenium.dev/documentation/webdriver
 [WebClient]: http://javadoc.jenkins-ci.org/org/jvnet/hudson/test/JenkinsRule.WebClient.html
 [WorkflowJobActionTest]: src/test/java/com/cloudbees/workflow/ui/view/WorkflowJobActionTest.java
-[AbstractPhantomJSTest]: src/test/java/com/cloudbees/workflow/ui/AbstractPhantomJSTest.java
+[AbstractWebDriverTest]: src/test/java/com/cloudbees/workflow/ui/AbstractPhantomJSTest.java
 [LESS]: http://lesscss.org/
 [workflow_less]: src/main/less/workflow.less
 [variables_less]: src/main/less/variables.less

--- a/ui/pom.xml
+++ b/ui/pom.xml
@@ -94,39 +94,15 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.jenkins-ci.plugins.workflow</groupId>
+            <artifactId>workflow-basic-steps</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.seleniumhq.selenium</groupId>
             <artifactId>selenium-java</artifactId>
             <version>4.28.1</version>
             <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.github.detro.ghostdriver</groupId>
-            <artifactId>phantomjsdriver</artifactId>
-            <version>1.1.0</version>
-            <scope>test</scope>
-            <exclusions>
-                <!-- Provided by bouncycastle-api plugin -->
-                <exclusion>
-                    <groupId>org.bouncycastle</groupId>
-                    <artifactId>bcpkix-jdk15on</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.bouncycastle</groupId>
-                    <artifactId>bcprov-jdk15on</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.seleniumhq.selenium</groupId>
-                    <artifactId>selenium-java</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.apache.httpcomponents</groupId>
-                    <artifactId>httpclient</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.mortbay.jetty</groupId>
-                    <artifactId>servlet-api-2.5</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
     </dependencies>
 
@@ -139,33 +115,6 @@
                 <directory>target/generated-adjuncts</directory>
             </resource>
         </resources>
-        <plugins>
-            <plugin>
-                <groupId>com.github.klieber</groupId>
-                <artifactId>phantomjs-maven-plugin</artifactId>
-                <version>0.6</version>
-                <executions>
-                    <execution>
-                        <phase>process-test-resources</phase>
-                        <goals>
-                            <goal>install</goal>
-                        </goals>
-                    </execution>
-                </executions>
-                <configuration>
-                    <version>1.9.7</version>
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <configuration>
-                    <systemPropertyVariables>
-                        <phantomjs.binary.path>${phantomjs.binary}</phantomjs.binary.path>
-                    </systemPropertyVariables>
-                </configuration>
-            </plugin>
-        </plugins>
     </build>
     <profiles>
         <profile>

--- a/ui/pom.xml
+++ b/ui/pom.xml
@@ -89,6 +89,17 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.jenkins-ci.plugins.workflow</groupId>
+            <artifactId>workflow-durable-task-step</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.seleniumhq.selenium</groupId>
+            <artifactId>selenium-java</artifactId>
+            <version>4.28.1</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>com.github.detro.ghostdriver</groupId>
             <artifactId>phantomjsdriver</artifactId>
             <version>1.1.0</version>

--- a/ui/src/main/java/com/cloudbees/workflow/ui/view/WorkflowStageViewAction.java
+++ b/ui/src/main/java/com/cloudbees/workflow/ui/view/WorkflowStageViewAction.java
@@ -54,8 +54,4 @@ public class WorkflowStageViewAction implements Action {
             return Collections.singleton(new WorkflowStageViewAction(target));
         }
     }
-
-    public String getTimeZone() {
-        return System.getProperty("user.timezone");
-    }
 }

--- a/ui/src/main/js/view/templates/index.js
+++ b/ui/src/main/js/view/templates/index.js
@@ -78,11 +78,6 @@ registerHBSHelper('formatDate', function (date, toFormat) {
         return date;
     }
 
-    var options = { month: 'short', day: '2-digit', hour: '2-digit', minute: '2-digit', hour12: false };
-    if (timeZone) {
-        options.timeZone = Intl.DateTimeFormat().resolvedOptions().timeZone;
-    }
-
     let userLocale
     if (navigator.languages && navigator.languages.length) {
         userLocale = navigator.languages[0]
@@ -90,17 +85,26 @@ registerHBSHelper('formatDate', function (date, toFormat) {
         userLocale = navigator.language
     }
 
+    let userTz;
+    if (typeof window !== "undefined" && window.timeZone) {
+        // from controller.jelly -> ControllerScript.js
+        userTz = window.timeZone;
+    } else {
+        userTz = Intl.DateTimeFormat().resolvedOptions().timeZone;
+    }
+
     var theDate = new Date(date);
     if (toFormat == 'month') {
-        return theDate.toLocaleDateString(userLocale, {month: 'short'});
+        return theDate.toLocaleDateString(userLocale, {month: 'short', timeZone: userTz});
     }
     if (toFormat == 'dom') {
-        return theDate.toLocaleDateString(userLocale, {day: '2-digit'});
+        return theDate.toLocaleDateString(userLocale, {day: '2-digit', timeZone: userTz});
     }
     if (toFormat == 'time') {
-        return theDate.toLocaleTimeString(userLocale, {hour: '2-digit',minute: '2-digit', hour12: false });
+        return theDate.toLocaleTimeString(userLocale, {hour: '2-digit', minute: '2-digit', hour12: false , timeZone: userTz});
     }
-    return theDate.toLocaleDateString(userLocale, options)
+
+    return theDate.toLocaleDateString(userLocale, {month: 'short', day: '2-digit', hour: '2-digit', minute: '2-digit', hour12: false , timeZone: userTz});
 });
 
 /**

--- a/ui/src/main/resources/com/cloudbees/workflow/controller.jelly
+++ b/ui/src/main/resources/com/cloudbees/workflow/controller.jelly
@@ -9,7 +9,7 @@
             Optional fragment caption, passed through to the controller.
         </st:attribute>
     </st:documentation>
-    <div id='timeparam' data-time='${it.timeZone}'/>
+    <div id='timeparam' data-time='${h.userTimeZone}'/>
     <st:adjunct includes="com.cloudbees.workflow.controllerScript"/>
     <div class="cbwf-stage-view">
         <div cbwf-controller="${name}" objectUrl="${rootURL}/${it.target.url}" fragCaption="${fragCaption}" />

--- a/ui/src/test/java/com/cloudbees/workflow/ui/AbstractPhantomJSTest.java
+++ b/ui/src/test/java/com/cloudbees/workflow/ui/AbstractPhantomJSTest.java
@@ -57,7 +57,6 @@ public abstract class AbstractPhantomJSTest {
 
     @BeforeClass
     public static void configure() throws IOException {
-        sCaps.setJavascriptEnabled(true);
         sCaps.setCapability("takesScreenshot", false);
         sCaps.setBrowserName("phantomjs");
 

--- a/ui/src/test/java/com/cloudbees/workflow/ui/AbstractWebDriverTest.java
+++ b/ui/src/test/java/com/cloudbees/workflow/ui/AbstractWebDriverTest.java
@@ -23,65 +23,75 @@
  */
 package com.cloudbees.workflow.ui;
 
-import hudson.model.Item;
-import jenkins.model.Jenkins;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.openqa.selenium.By;
-import org.openqa.selenium.WebDriver;
-import org.openqa.selenium.WebElement;
-import org.openqa.selenium.interactions.Actions;
-import org.openqa.selenium.phantomjs.PhantomJSDriver;
-import org.openqa.selenium.phantomjs.PhantomJSDriverService;
-import org.openqa.selenium.remote.DesiredCapabilities;
-
-import java.io.File;
-import java.io.IOException;
-import java.util.ArrayList;
+import java.time.Duration;
 import java.util.Collections;
 import java.util.List;
 
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Assume;
+import org.junit.Before;
+import org.openqa.selenium.By;
+import org.openqa.selenium.TimeoutException;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.chrome.ChromeDriver;
+import org.openqa.selenium.chrome.ChromeOptions;
+import org.openqa.selenium.interactions.Actions;
+import org.openqa.selenium.support.ui.ExpectedConditions;
+import org.openqa.selenium.support.ui.WebDriverWait;
+
+import hudson.model.Item;
+import jenkins.model.Jenkins;
+
 /**
- * Abstract base class for running phantomJS based tests.
+ * Abstract base class for running web based tests.
  * <p/>
- * Why not just use HtmlUnit?  Coz it's a pain wrt javascript.
+ * Why not just use HtmlUnit?  Coz it's a pain wrt javascript and it doesn't support toLocaleDateString
  *
  * @author <a href="mailto:tom.fennelly@gmail.com">tom.fennelly@gmail.com</a>
  */
-public abstract class AbstractPhantomJSTest {
+public abstract class AbstractWebDriverTest {
 
-    private static DesiredCapabilities sCaps = new DesiredCapabilities();
-    private WebDriver mDriver = null;
-
-    @BeforeClass
-    public static void configure() throws IOException {
-        sCaps.setCapability("takesScreenshot", false);
-        sCaps.setBrowserName("phantomjs");
-
-        ArrayList<String> cliArgsCap = new ArrayList<String>();
-        cliArgsCap.add("--web-security=false");
-        cliArgsCap.add("--ssl-protocol=any");
-        cliArgsCap.add("--ignore-ssl-errors=true");
-        sCaps.setCapability(PhantomJSDriverService.PHANTOMJS_CLI_ARGS, cliArgsCap);
-
-        // Set LogLevel for GhostDriver
-        sCaps.setCapability(PhantomJSDriverService.PHANTOMJS_GHOSTDRIVER_CLI_ARGS, new String[]{"--logLevel=DEBUG"});
-    }
+    protected WebDriver driver;
 
     @Before
-    public void prepareDriver() {
+    public void setUp() {
+        // Only run if ChromeDriver is available
         try {
-            assertPhantomJSExecPathOK();
-            mDriver = new PhantomJSDriver(sCaps);
+            Class.forName("org.openqa.selenium.chrome.ChromeDriver");
+        } catch (ClassNotFoundException e) {
+            Assume.assumeTrue("ChromeDriver not available, skipping Selenium timezone test.", false);
+        }
+        ChromeOptions options = new ChromeOptions();
+        options.addArguments("--headless=new", "--no-sandbox", "--disable-dev-shm-usage");
+        driver = new ChromeDriver(options);
+
+        try {
+            driver.get("data:text/html, <form id='f' onsubmit='document.body.textContent=\"ok\"; return false;'>"
+                    + "<button id='b' type='submit'>Go</button></form>");
+            driver.findElement(By.id("b")).click();
+            try {
+                new WebDriverWait(driver, Duration.ofSeconds(2))
+                        .until(ExpectedConditions.textToBePresentInElementLocated(By.tagName("body"), "ok"));
+            } catch (TimeoutException te) {
+                Assume.assumeTrue("Chrome crashed or JS submit broken: " + te, false);
+            }
         } catch (Exception e) {
-            Assert.fail("Unable to create PhantomJS WebDriver.  PhantomJS must be installed on the machine executing the tests.  Exception: " + e.getMessage());
+            Assume.assumeTrue("Skipping test because Chrome crashed: " + e, false);
+        }
+    }
+
+    @After
+    public void tearDown() {
+        if (driver != null) {
+            driver.quit();
+            driver = null;
         }
     }
 
     protected WebDriver getWebDriver() {
-        return mDriver;
+        return driver;
     }
 
     protected void moveMouseToElement(WebDriver webdriver, WebElement element) {
@@ -135,37 +145,11 @@ public abstract class AbstractPhantomJSTest {
         waitForElementsRemoved(webdriver.findElement(By.cssSelector("html")), cssSelector);
     }
 
-    @After
-    public void quitDriver() {
-        if (mDriver != null) {
-            mDriver.quit();
-            mDriver = null;
-        }
-    }
-
     protected String getItemUrl(Jenkins jenkins, Item item) {
         return getJenkinsUrl(jenkins, item.getUrl());
     }
 
     protected String getJenkinsUrl(Jenkins jenkins, String itemUrl) {
         return jenkins.getRootUrl() + itemUrl;
-    }
-
-    private static void assertPhantomJSExecPathOK() {
-        String phantomJsExePath = System.getProperty(PhantomJSDriverService.PHANTOMJS_EXECUTABLE_PATH_PROPERTY);
-        if (phantomJsExePath != null) {
-            if (!(new File(phantomJsExePath).exists())) {
-                System.out.println("***************************************************************************************");
-                System.out.println(PhantomJSDriverService.PHANTOMJS_EXECUTABLE_PATH_PROPERTY + " system property is set to '" + phantomJsExePath + "'.");
-                System.out.println("No such file exists.  Test may be running in an IDE?");
-                System.out.println("Removing system property in the hope that phantomjs can be found on the path.");
-                System.out.println("***************************************************************************************");
-                System.getProperties().remove(PhantomJSDriverService.PHANTOMJS_EXECUTABLE_PATH_PROPERTY);
-            } else {
-                System.out.println(PhantomJSDriverService.PHANTOMJS_EXECUTABLE_PATH_PROPERTY + " system property is set to '" + phantomJsExePath + "'.");
-            }
-        } else {
-            System.out.println(PhantomJSDriverService.PHANTOMJS_EXECUTABLE_PATH_PROPERTY + " system property not set.  Will try use the system path.");
-        }
     }
 }

--- a/ui/src/test/java/com/cloudbees/workflow/ui/view/FailedJobTest.java
+++ b/ui/src/test/java/com/cloudbees/workflow/ui/view/FailedJobTest.java
@@ -23,43 +23,39 @@
  */
 package com.cloudbees.workflow.ui.view;
 
-import com.cloudbees.workflow.ui.AbstractPhantomJSTest;
+import com.cloudbees.workflow.ui.AbstractWebDriverTest;
 import hudson.model.Result;
 import hudson.model.queue.QueueTaskFuture;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 import org.junit.Assert;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.ui.WebDriverWait;
 
+import java.time.Duration;
 import java.util.List;
 
 /**
  * @author <a href="mailto:tom.fennelly@gmail.com">tom.fennelly@gmail.com</a>
  */
-public class FailedJobTest extends AbstractPhantomJSTest {
+public class FailedJobTest extends AbstractWebDriverTest {
 
     @Rule
     public JenkinsRule jenkinsRule = new JenkinsRule();
 
-    @Ignore("remove phantomjs: https://trello.com/c/JpUg8S5z/159-get-rid-of-phantomjs-webdriver")
     @Test
     public void test() throws Exception {
         WebDriver webdriver = getWebDriver();
 
         WorkflowJob job = jenkinsRule.jenkins.createProject(WorkflowJob.class, "Noddy Job");
 
-        job.setDefinition(new CpsFlowDefinition("" +
-                "node {" +
-                "   stage ('Build'); " +
-                "   sh ('blah'); " +
-                "}", true));
+        job.setDefinition(new CpsFlowDefinition("node { stage ('Build'); sh ('blah'); }", true));
 
         QueueTaskFuture<WorkflowRun> build = job.scheduleBuild2(0);
         jenkinsRule.assertBuildStatus(Result.FAILURE, build.get());
@@ -68,7 +64,11 @@ public class FailedJobTest extends AbstractPhantomJSTest {
         webdriver.get(jobUrl);
 
         // Make sure the stage cell was marked as failed...
-        List<WebElement> failedStageCells = webdriver.findElements(By.cssSelector(".stage-cell.FAILED .stage-wrapper"));
+        WebDriverWait wait = new WebDriverWait(driver, Duration.ofSeconds(10));
+        List<WebElement> failedStageCells = wait.until(driver1 -> {
+            List<WebElement> elements = driver1.findElements(By.cssSelector(".stage-cell.FAILED .stage-wrapper"));
+            return elements.isEmpty() ? null : elements;
+        });
         Assert.assertEquals(1, failedStageCells.size());
 
         // Make the sure the stage-failed-popover widget was added to the cell
@@ -79,17 +79,17 @@ public class FailedJobTest extends AbstractPhantomJSTest {
         // Make sure that when we mouse over the failed stage cell we get a popup...
         moveMouseToElement(webdriver, failedStageCell);
         List<WebElement> popovers = waitForElementsAdded(webdriver, ".cbwf-popover");
-//        System.out.println(webdriver.getPageSource());
         Assert.assertTrue(popovers.size() > 0);
 
         // Make sure the popover has what we expect...
-        Assert.assertEquals("Failed with the following error(s)\n" +
-                "Shell Script script returned exit code 127\n" +
-                "See stage logs for more detail.\n" +
-                "Logs", popovers.get(0).getText().trim());
+        Assert.assertEquals(
+                "Failed with the following error(s)\n"
+                        + "Shell Script script returned exit code 127\n"
+                        + "See stage logs for more detail.\nLogs",
+                popovers.get(0).getText().trim());
 
         // Make sure the popover is removed once we move off it
-        //moveMouseOffElement(webdriver);
-        //waitForElementsRemoved(webdriver, ".cbwf-popover");
+        moveMouseOffElement(webdriver);
+        waitForElementsRemoved(webdriver, ".cbwf-popover");
     }
 }

--- a/ui/src/test/java/com/cloudbees/workflow/ui/view/PausedJobTest.java
+++ b/ui/src/test/java/com/cloudbees/workflow/ui/view/PausedJobTest.java
@@ -23,51 +23,51 @@
  */
 package com.cloudbees.workflow.ui.view;
 
-import com.cloudbees.workflow.ui.AbstractPhantomJSTest;
-import hudson.model.queue.QueueTaskFuture;
+import java.time.Duration;
+import java.util.List;
+
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowExecution;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 import org.jenkinsci.plugins.workflow.support.steps.input.InputAction;
 import org.junit.Assert;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.ui.WebDriverWait;
 
-import java.util.List;
+import com.cloudbees.workflow.ui.AbstractWebDriverTest;
+import com.cloudbees.workflow.ui.Util;
+
+import hudson.model.Result;
+import hudson.model.queue.QueueTaskFuture;
 
 /**
  * @author <a href="mailto:tom.fennelly@gmail.com">tom.fennelly@gmail.com</a>
  */
-public class PausedJobTest extends AbstractPhantomJSTest {
+public class PausedJobTest extends AbstractWebDriverTest {
 
     @Rule
     public JenkinsRule jenkinsRule = new JenkinsRule();
 
-    @Ignore("remove phantomjs: https://trello.com/c/JpUg8S5z/159-get-rid-of-phantomjs-webdriver")
     @Test
     public void test() throws Exception {
         WebDriver webdriver = getWebDriver();
 
         WorkflowJob job = jenkinsRule.jenkins.createProject(WorkflowJob.class, "Noddy Job");
 
-        job.setDefinition(new CpsFlowDefinition("" +
-                "node {" +
-                "   stage ('Build'); " +
-                "   echo ('build'); " +
-                "   input (message: 'Is the build okay?'); " +
-                "}", true));
+        job.setDefinition(
+                new CpsFlowDefinition("node { stage ('Build'); echo ('build'); input 'Is the build okay?' }", true));
 
         QueueTaskFuture<WorkflowRun> q = job.scheduleBuild2(0);
         WorkflowRun b = q.getStartCondition().get();
         CpsFlowExecution e = (CpsFlowExecution) b.getExecutionPromise().get();
 
-        while (b.getAction(InputAction.class)==null) {
+        while (b.getAction(InputAction.class) == null) {
             e.waitForSuspension();
         }
 
@@ -75,7 +75,12 @@ public class PausedJobTest extends AbstractPhantomJSTest {
         webdriver.get(jobUrl);
 
         // Make sure the stage cell was marked as pending input...
-        List<WebElement> pausedStageCells = webdriver.findElements(By.cssSelector(".stage-cell.PAUSED_PENDING_INPUT .stage-wrapper"));
+        WebDriverWait wait = new WebDriverWait(driver, Duration.ofSeconds(10));
+        List<WebElement> pausedStageCells = wait.until(driver1 -> {
+            List<WebElement> elements =
+                    driver1.findElements(By.cssSelector(".stage-cell.PAUSED_PENDING_INPUT .stage-wrapper"));
+            return elements.isEmpty() ? null : elements;
+        });
         Assert.assertEquals(1, pausedStageCells.size());
 
         // Move over the paused build and check for the popup...
@@ -85,17 +90,17 @@ public class PausedJobTest extends AbstractPhantomJSTest {
 
         // Check the popup content...
         WebElement inputRequiredPopover = inputRequiredPopovers.get(0);
-        WebElement message = inputRequiredPopover.findElement(By.cssSelector(".message"));
+        WebElement message = inputRequiredPopover.findElement(By.className("caption"));
         Assert.assertEquals("Is the build okay?", message.getText());
 
         // Click on the proceed button
-        WebElement proceedBtn = inputRequiredPopover.findElement(By.cssSelector(".action.proceed"));
-//        clickOnElement(webdriver, proceedBtn);
-//
-//        // Wait for the build to complete successfully
-//        Util.waitForBuildCount(job, 1, Result.SUCCESS);
-//
-//        // Click on the proceed button and wait for the popup to disappear
-//        waitForElementsRemoved(webdriver, ".cbwf-popover .run-input-required");
+        WebElement proceedBtn = inputRequiredPopover.findElement(By.className("proceed-button"));
+        clickOnElement(webdriver, proceedBtn);
+
+        // Wait for the build to complete successfully
+        Util.waitForBuildCount(job, 1, Result.SUCCESS);
+
+        // Click on the proceed button and wait for the popup to disappear
+        waitForElementsRemoved(webdriver, ".cbwf-popover .run-input-required");
     }
 }

--- a/ui/src/test/java/com/cloudbees/workflow/ui/view/WorkflowStageViewActionTest.java
+++ b/ui/src/test/java/com/cloudbees/workflow/ui/view/WorkflowStageViewActionTest.java
@@ -77,8 +77,8 @@ public class WorkflowStageViewActionTest {
         driver = new ChromeDriver(options);
 
         try {
-            driver.get("about:blank");
-            driver.findElement(By.tagName("body"));
+            driver.get("data:text/html,<button id='t'>t</button>");
+            driver.findElement(By.id("t")).click();
         } catch (Exception e) {
             Assume.assumeTrue("Skipping test because Chrome crashed: " + e, false);
         }

--- a/ui/src/test/java/com/cloudbees/workflow/ui/view/WorkflowStageViewActionTest.java
+++ b/ui/src/test/java/com/cloudbees/workflow/ui/view/WorkflowStageViewActionTest.java
@@ -23,35 +23,70 @@
  */
 package com.cloudbees.workflow.ui.view;
 
-import com.cloudbees.workflow.ui.AbstractPhantomJSTest;
-import hudson.model.queue.QueueTaskFuture;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+
+import org.htmlunit.html.HtmlElement;
+import org.htmlunit.html.HtmlPage;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
+import org.junit.After;
 import org.junit.Assert;
-import org.junit.Ignore;
+import org.junit.Assume;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.openqa.selenium.By;
+import org.openqa.selenium.JavascriptExecutor;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
+import org.openqa.selenium.chrome.ChromeDriver;
+import org.openqa.selenium.chrome.ChromeOptions;
+import org.openqa.selenium.support.ui.WebDriverWait;
 
-import java.util.List;
+import hudson.model.TimeZoneProperty;
+import hudson.model.User;
 
 /**
  * @author <a href="mailto:tom.fennelly@gmail.com">tom.fennelly@gmail.com</a>
  */
-public class WorkflowStageViewActionTest extends AbstractPhantomJSTest {
+public class WorkflowStageViewActionTest {
 
     @Rule
     public JenkinsRule jenkinsRule = new JenkinsRule();
 
-    @Ignore("remove phantomjs: https://trello.com/c/JpUg8S5z/159-get-rid-of-phantomjs-webdriver")
+    private WebDriver driver;
+
+    @Before
+    public void setUp() {
+        // Only run if ChromeDriver is available
+        try {
+            Class.forName("org.openqa.selenium.chrome.ChromeDriver");
+        } catch (ClassNotFoundException e) {
+            System.out.println("ChromeDriver not available, skipping Selenium timezone test.");
+            Assume.assumeTrue(false);
+        }
+        ChromeOptions options = new ChromeOptions();
+        options.addArguments("--headless=new");
+        driver = new ChromeDriver(options);
+    }
+
+    @After
+    public void tearDown() {
+        if (driver != null) {
+            driver.quit();
+        }
+    }
+
     @Test
     public void test() throws Exception {
-        WebDriver webdriver = getWebDriver();
-
         WorkflowJob job = jenkinsRule.jenkins.createProject(WorkflowJob.class, "Noddy Job");
 
         job.setDefinition(new CpsFlowDefinition("" +
@@ -64,28 +99,110 @@ public class WorkflowStageViewActionTest extends AbstractPhantomJSTest {
                 "   sh ('echo Deploying'); " +
                 "}", true));
 
-        QueueTaskFuture<WorkflowRun> build = job.scheduleBuild2(0);
+        WorkflowRun build = job.scheduleBuild2(0).get();
         jenkinsRule.assertBuildStatusSuccess(build);
 
-        String jobUrl = getItemUrl(jenkinsRule.jenkins, job);
-        webdriver.get(jobUrl);
-
-//        System.out.println(webdriver.getPageSource());
+        HtmlPage page = jenkinsRule.createWebClient().goTo(job.getUrl());
 
         // Make sure the jobsTable is rendered in the page
-        WebElement jobsTable = webdriver.findElement(By.className("jobsTable"));
+        HtmlElement jobsTable = page.getFirstByXPath("//table[contains(@class,'jobsTable')]");
         Assert.assertNotNull(jobsTable);
 
-        // Check the totals are rendered
-//        List<WebElement> stageWrappers = jobsTable.findElements(By.cssSelector(".totals .stage-wrapper"));
-//        Assert.assertEquals(3, stageWrappers.size());
-
         // Should have just one job
-        List<WebElement> jobs = jobsTable.findElements(By.cssSelector(".job"));
+        List<HtmlElement> jobs = jobsTable.getByXPath(".//tr[contains(@class,'job')]");
         Assert.assertEquals(1, jobs.size());
 
         // That job should have 3 stages
-        List<WebElement> jobStages = jobs.get(0).findElements(By.cssSelector(".stage-wrapper"));
+        List<HtmlElement> jobStages = jobs.get(0).getByXPath(".//div[contains(@class,'stage-wrapper')]");
         Assert.assertEquals(3, jobStages.size());
+    }
+
+    @Test
+    public void testTimezoneRespectedInStageStartTime() throws Exception {
+        // Given a jenkins instance
+        jenkinsRule.jenkins.setSecurityRealm(jenkinsRule.createDummySecurityRealm());
+        // And a simple pipeline project with a successful execution
+        WorkflowJob job = jenkinsRule.jenkins.createProject(WorkflowJob.class, "TZ Job");
+        String pipelineScript = "node { stage ('Build'); sh ('echo Building'); }";
+        System.out.println("Pipeline script for testTimezoneRespectedInStageStartTime():\n" + pipelineScript);
+        job.setDefinition(new CpsFlowDefinition(pipelineScript, true));
+        WorkflowRun build = job.scheduleBuild2(0).get();
+        jenkinsRule.assertBuildStatusSuccess(build);
+        long startMillis = build.getStartTimeInMillis();
+        Instant startInstant = Instant.ofEpochMilli(startMillis);
+        // And a browser with a configured timezone
+        String browserTz = (String)
+                ((JavascriptExecutor) driver).executeScript("return Intl.DateTimeFormat().resolvedOptions().timeZone;");
+        ZoneId browserZoneId = ZoneId.of(browserTz);
+        // And some users with different timezone preferences
+        class UserTZ {
+            final String userId;
+            final String tz;
+            final ZoneId expectedZoneId;
+
+            UserTZ(String userId, String tz, ZoneId expectedZoneId) {
+                this.userId = userId;
+                this.tz = tz;
+                this.expectedZoneId = expectedZoneId;
+            }
+        }
+        Collection<UserTZ> users = Arrays.asList(
+                new UserTZ("a", "Australia/Sydney", ZoneId.of("Australia/Sydney")),
+                new UserTZ("b", "America/New_York", ZoneId.of("America/New_York")),
+                // Null or invalid timezone property fallback is browser timezone
+                new UserTZ("c", null, browserZoneId),
+                new UserTZ("d", "Invalid/Zone", browserZoneId));
+        for (UserTZ utz : users) {
+            User user = User.getById(utz.userId, true);
+            if (utz.tz != null) {
+                user.addProperty(new TimeZoneProperty(utz.tz));
+            }
+            user.save();
+        }
+
+        for (UserTZ utz : users) {
+            // When the user logs in and access the job page
+            driver.get(jenkinsRule.getURL().toString() + "login");
+            driver.findElement(By.name("j_username")).sendKeys(utz.userId);
+            driver.findElement(By.name("j_password")).sendKeys(utz.userId);
+            driver.findElement(By.name("Submit")).click();
+            WebDriverWait loginWait = new WebDriverWait(driver, Duration.ofSeconds(10));
+            loginWait.until(d ->
+                    d.findElements(By.xpath("//a[contains(@href, 'logout')]")).size() > 0);
+            driver.get(jenkinsRule.getURL().toString() + job.getUrl());
+            WebDriverWait wait = new WebDriverWait(driver, Duration.ofSeconds(10));
+            String renderedDate = wait.until(driver1 -> {
+                        List<WebElement> elements = driver1.findElements(
+                                By.xpath("//div[contains(@class,'stage-start-time')]/div[@class='date']"));
+                        return elements.isEmpty() ? null : elements.get(0);
+                    })
+                    .getText();
+            String renderedTime = wait.until(driver1 -> {
+                        List<WebElement> elements = driver1.findElements(
+                                By.xpath("//div[contains(@class,'stage-start-time')]/div[@class='time']"));
+                        return elements.isEmpty() ? null : elements.get(0);
+                    })
+                    .getText();
+
+            // Then the rendered stage start date use the expected timezone
+            ZoneId zoneId = utz.expectedZoneId;
+            ZonedDateTime zdt = ZonedDateTime.ofInstant(startInstant, zoneId);
+            String expectedMonth = zdt.getMonth().toString().substring(0, 1)
+                    + zdt.getMonth().toString().substring(1, 3).toLowerCase();
+            // NOTE toLocaleTimeString day: '2-digit'
+            String expectedDay = String.format("%02d", zdt.getDayOfMonth());
+            boolean matchesDate = renderedDate.contains(expectedMonth) && renderedDate.contains(expectedDay);
+            Assert.assertTrue(
+                    "Rendered date '" + renderedDate + "' should contain expected month '" + expectedMonth
+                            + "' and day '" + expectedDay + "' for timezone " + zoneId + " (user " + utz.userId + ")",
+                    matchesDate);
+            // And the rendered stage start time use the expected timezone
+            // NOTE toLocaleTimeString hour12: false / day: '2-digit'
+            String expectedTime = String.format("%02d:%02d", zdt.getHour(), zdt.getMinute());
+            Assert.assertTrue(
+                    "Rendered time '" + renderedTime + "' should match expected time " + expectedTime + " for timezone "
+                            + zoneId + " (user " + utz.userId + ")",
+                    renderedTime.contains(expectedTime));
+        }
     }
 }

--- a/ui/src/test/java/com/cloudbees/workflow/ui/view/WorkflowStageViewActionTest.java
+++ b/ui/src/test/java/com/cloudbees/workflow/ui/view/WorkflowStageViewActionTest.java
@@ -36,22 +36,16 @@ import org.htmlunit.html.HtmlPage;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
-import org.junit.After;
 import org.junit.Assert;
-import org.junit.Assume;
-import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.openqa.selenium.By;
 import org.openqa.selenium.JavascriptExecutor;
-import org.openqa.selenium.TimeoutException;
-import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
-import org.openqa.selenium.chrome.ChromeDriver;
-import org.openqa.selenium.chrome.ChromeOptions;
-import org.openqa.selenium.support.ui.ExpectedConditions;
 import org.openqa.selenium.support.ui.WebDriverWait;
+
+import com.cloudbees.workflow.ui.AbstractWebDriverTest;
 
 import hudson.model.TimeZoneProperty;
 import hudson.model.User;
@@ -59,46 +53,10 @@ import hudson.model.User;
 /**
  * @author <a href="mailto:tom.fennelly@gmail.com">tom.fennelly@gmail.com</a>
  */
-public class WorkflowStageViewActionTest {
+public class WorkflowStageViewActionTest extends AbstractWebDriverTest {
 
     @Rule
     public JenkinsRule jenkinsRule = new JenkinsRule();
-
-    private WebDriver driver;
-
-    @Before
-    public void setUp() {
-        // Only run if ChromeDriver is available
-        try {
-            Class.forName("org.openqa.selenium.chrome.ChromeDriver");
-        } catch (ClassNotFoundException e) {
-            Assume.assumeTrue("ChromeDriver not available, skipping Selenium timezone test.", false);
-        }
-        ChromeOptions options = new ChromeOptions();
-        options.addArguments("--headless=new", "--no-sandbox", "--disable-dev-shm-usage");
-        driver = new ChromeDriver(options);
-
-        try {
-            driver.get("data:text/html, <form id='f' onsubmit='document.body.textContent=\"ok\"; return false;'>"
-                    + "<button id='b' type='submit'>Go</button></form>");
-            driver.findElement(By.id("b")).click();
-            try {
-                new WebDriverWait(driver, Duration.ofSeconds(2))
-                        .until(ExpectedConditions.textToBePresentInElementLocated(By.tagName("body"), "ok"));
-            } catch (TimeoutException te) {
-                Assume.assumeTrue("Chrome crashed or JS submit broken: " + te, false);
-            }
-        } catch (Exception e) {
-            Assume.assumeTrue("Skipping test because Chrome crashed: " + e, false);
-        }
-    }
-
-    @After
-    public void tearDown() {
-        if (driver != null) {
-            driver.quit();
-        }
-    }
 
     @Test
     public void test() throws Exception {

--- a/ui/src/test/java/com/cloudbees/workflow/ui/view/WorkflowStageViewActionTest.java
+++ b/ui/src/test/java/com/cloudbees/workflow/ui/view/WorkflowStageViewActionTest.java
@@ -70,12 +70,18 @@ public class WorkflowStageViewActionTest {
         try {
             Class.forName("org.openqa.selenium.chrome.ChromeDriver");
         } catch (ClassNotFoundException e) {
-            System.out.println("ChromeDriver not available, skipping Selenium timezone test.");
-            Assume.assumeTrue(false);
+            Assume.assumeTrue("ChromeDriver not available, skipping Selenium timezone test.", false);
         }
         ChromeOptions options = new ChromeOptions();
         options.addArguments("--headless=new");
         driver = new ChromeDriver(options);
+
+        try {
+            driver.get("about:blank");
+            driver.findElement(By.tagName("body"));
+        } catch (Exception e) {
+            Assume.assumeTrue("Skipping test because Chrome crashed: " + e, false);
+        }
     }
 
     @After


### PR DESCRIPTION
Ensure that  stage start **date and time** displays in the UI use the Jenkins user's preferred timezone if set, or the browser's timezone as a fallback. The system timezone is **never** used for display, aligning the stage view plugin with the job build list widget, [HistoryWidget](https://github.com/jenkinsci/jenkins/blob/master/core/src/main/resources/hudson/widgets/HistoryWidget/entry.jelly), and reverting the behavior introduced in  [#236](https://github.com/jenkinsci/pipeline-stage-view-plugin/pull/236)

**With this change, the system timezone is no longer used for display. The precedence is:**
1. Jenkins user preferences - `hudson.model.TimeZoneProperty` (via jelly tag `h.userTimeZone`)
2. Browser preferences (via `Intl.DateTimeFormat().resolvedOptions().timeZone`)

:speaking_head:  :information_source:  User locale and the format of the date/time (e.g., using 12h with or without AM/PM) are out of the scope of this PR, as adapting to those would require additional CSS changes to avoid breaking the render. `index.js` **still** contains this _hardcoded_ values : `month: 'short', day: '2-digit', hour: '2-digit', minute: '2-digit', hour12: false`.
**This PR address the data but reuse the same presentation**.


### :mega: Testing Notes 👻🚫 
- ~~**Currently, all the HTML tests are disabled pending a fix for PhantomJS.**~~
- To ensure the logic in `index.js` is executed, a standard Selenium driver is now used in the test. If there are better approaches (e.g., using ATH), suggestions are welcome.
  - **All the disabled `PhantomJS` tests are now migrated to `WebDriver` chrome**
- `WorkflowStageViewActionTest` has been updated to use HtmlUnit. However, HtmlUnit does not support `toLocaleDateString`, which required extra effort and a hell of debugging :rage3: .


###  Testing done
Apart of the introduced ITs I manually verified this using this steps:
* mvn hpi:run
* create a simple pipeline with stages and execute it
<img width="1000" height="422" alt="image" src="https://github.com/user-attachments/assets/2281ea5f-0ccb-4c67-bd86-fd1222f97134" />

* create a user and use the script console to update 
```groovy
def user = hudson.model.User.getById("userInAustralia", false)
user.addProperty(new hudson.model.TimeZoneProperty("Australia/Sydney"))
user.save()
```
* login with this user
<img width="1000" height="422" alt="image" src="https://github.com/user-attachments/assets/c9a14f0c-c6f6-4872-8dbd-9da566b2f988" />

> [!NOTE]  
> 8:30 PM vs 20:30

* **before the fix**
<img width="1000" height="422" alt="image" src="https://github.com/user-attachments/assets/edbb1bc2-0de4-4a50-8a1e-36bd9e143bbb" />



### REFERENCES
- See [JENKINS-35656](https://issues.jenkins.io/browse/JENKINS-35656)
- See [JENKINS-70175](https://issues.jenkins.io/browse/JENKINS-70175) 
- Reference: [#236](https://github.com/jenkinsci/pipeline-stage-view-plugin/pull/236)


### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed