### PR TITLE
Fix for JENKINS-49179: compute queueDurationMillis on runs and stage nodes

### DIFF
--- a/rest-api/src/main/java/com/cloudbees/workflow/flownode/FlowNodeUtil.java
+++ b/rest-api/src/main/java/com/cloudbees/workflow/flownode/FlowNodeUtil.java
@@ -41,11 +41,14 @@ import org.jenkinsci.plugins.workflow.actions.ErrorAction;
 import org.jenkinsci.plugins.workflow.actions.NotExecutedNodeAction;
 import org.jenkinsci.plugins.workflow.actions.TimingAction;
 import org.jenkinsci.plugins.workflow.flow.FlowExecution;
+import org.jenkinsci.plugins.workflow.graph.BlockStartNode;
 import org.jenkinsci.plugins.workflow.graph.FlowEndNode;
 import org.jenkinsci.plugins.workflow.graph.FlowNode;
+import org.jenkinsci.plugins.workflow.graph.StepNode;
 import org.jenkinsci.plugins.workflow.graphanalysis.ForkScanner;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
+import org.jenkinsci.plugins.workflow.steps.StepDescriptor;
 import org.jenkinsci.plugins.workflow.support.actions.PauseAction;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
@@ -166,6 +169,32 @@ public class FlowNodeUtil {
      */
     public static boolean isPauseNode(FlowNode flowNode) {
         return PauseAction.isPaused(flowNode);
+    }
+
+    /**
+     * Best-effort computation of the time spent waiting for an executor inside a {@code node} block.
+     * A {@code node} step's {@link BlockStartNode} is created as soon as the step is scheduled, while the
+     * first {@link FlowNode} it contains only starts once an executor has actually been allocated, so the
+     * gap between the two start times is executor queue wait that isn't otherwise accounted for.
+     * Returns {@code 0} if the node isn't a {@code node} block start, or the wait can't be determined.
+     * @param node the candidate block start node.
+     * @param after the node immediately following {@code node} in the flow graph, if known.
+     */
+    public static long getInternalQueueWaitMillis(@NonNull FlowNode node, @CheckForNull FlowNode after) {
+        if (after == null || !(node instanceof BlockStartNode) || !(node instanceof StepNode)) {
+            return 0;
+        }
+        StepDescriptor descriptor = ((StepNode) node).getDescriptor();
+        if (descriptor == null || !"node".equals(descriptor.getFunctionName())) {
+            return 0;
+        }
+        TimingAction nodeTiming = node.getPersistentAction(TimingAction.class);
+        TimingAction afterTiming = after.getPersistentAction(TimingAction.class);
+        if (nodeTiming == null || afterTiming == null) {
+            return 0;
+        }
+        long wait = afterTiming.getStartTime() - nodeTiming.getStartTime();
+        return wait > 0 ? wait : 0;
     }
 
     // Enables us to get the status of a node without creating a bunch of objects

--- a/rest-api/src/main/java/com/cloudbees/workflow/rest/external/ChunkVisitor.java
+++ b/rest-api/src/main/java/com/cloudbees/workflow/rest/external/ChunkVisitor.java
@@ -1,5 +1,6 @@
 package com.cloudbees.workflow.rest.external;
 
+import com.cloudbees.workflow.flownode.FlowNodeUtil;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
@@ -36,6 +37,8 @@ public class ChunkVisitor extends StandardChunkVisitor {
     WorkflowRun run;
     ArrayList<String> stageNodeIds = new ArrayList<>();
     boolean isLastChunk = true;
+    /** Time spent waiting for an executor inside {@code node} blocks within the current stage chunk. */
+    long internalQueueDurationMillis = 0;
 
     public ChunkVisitor(@NonNull WorkflowRun run) {
         this.run = run;
@@ -82,6 +85,11 @@ public class ChunkVisitor extends StandardChunkVisitor {
             times = new TimingInfo(0, 0, run.getStartTimeInMillis());
         }
         ExecDuration dur = (times == null) ? new ExecDuration() : new ExecDuration(times);
+        if (internalQueueDurationMillis > 0) {
+            // `node` blocks inside this stage may have had to wait for an executor; that wait is counted as
+            // queue time, not stage execution time, so keep it out of the stage duration too.
+            dur.setTotalDurationMillis(Math.max(0, dur.getTotalDurationMillis() - internalQueueDurationMillis));
+        }
 
         GenericStatus status;
         long startTime = 0;
@@ -95,6 +103,7 @@ public class ChunkVisitor extends StandardChunkVisitor {
         // TODO add and use pipeline graph analysis API to allow us to get most of the metadata for the chunk in 1 pass, efficiently
         //  and only store the FlowNodes -- not the materialized objects.
         stageExt.addBasicNodeData(chunk.getFirstNode(), "", dur, startTime, StatusExt.fromGenericStatus(status), chunk.getLastNode().getError());
+        stageExt.setQueueDurationMillis(internalQueueDurationMillis);
 
         int childNodeLength = Math.min(StageNodeExt.MAX_CHILD_NODES, stageContents.size());
         ArrayList<AtomFlowNodeExt> internals = new ArrayList<>(childNodeLength);
@@ -112,6 +121,7 @@ public class ChunkVisitor extends StandardChunkVisitor {
         firstExecuted = null;
         stageNodeIds.clear();
         stageContents.clear();
+        internalQueueDurationMillis = 0;
     }
 
     @Override
@@ -135,6 +145,7 @@ public class ChunkVisitor extends StandardChunkVisitor {
         stageNodeIds.clear();
         chunk.setPauseTimeMillis(0);
         firstExecuted = null;
+        internalQueueDurationMillis = 0;
 
         // if we're using marker-based (and not block-scoped) stages, add the last node as part of its contents
         if (!(endNode instanceof BlockEndNode)) {
@@ -142,12 +153,25 @@ public class ChunkVisitor extends StandardChunkVisitor {
         }
     }
 
+    @SuppressFBWarnings(value = "RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE", justification = "We can actually get nulls")
     public void atomNode(@CheckForNull FlowNode before, @NonNull FlowNode atomNode, @CheckForNull FlowNode after, @NonNull ForkScanner scan) {
         if (NotExecutedNodeAction.isExecuted(atomNode)) {
             firstExecuted = atomNode;
         }
         long pause = PauseAction.getPauseDuration(atomNode);
         chunk.setPauseTimeMillis(chunk.getPauseTimeMillis()+pause);
+        long queueWaitMillis = FlowNodeUtil.getInternalQueueWaitMillis(atomNode, after);
+        if (queueWaitMillis > 0) {
+            if (chunk.getLastNode() == null) {
+                // No stage chunk is currently active, so this node (e.g. an outer `node` block wrapping the
+                // whole run) falls outside any stage boundary and its queue wait would otherwise be lost.
+                // Since chunks are visited in reverse, the first stage chronologically has already been
+                // materialized by the time we get here, so attribute the wait to it directly.
+                attributeQueueWaitToFirstStage(queueWaitMillis);
+            } else {
+                internalQueueDurationMillis += queueWaitMillis;
+            }
+        }
 
         // TODO this is rather inefficient, we should optimize to use a circular buffer or ArrayList with limited size
         // And then only create the node container objects when we hit the start (doing timing ETC at that point)
@@ -156,6 +180,19 @@ public class ChunkVisitor extends StandardChunkVisitor {
             stageContents.push(ext);
         }
         stageNodeIds.add(atomNode.getId());
+    }
+
+    /**
+     * Attributes queue wait detected while no stage chunk is active to the first stage executed
+     * chronologically, keeping stage queue duration and stage duration consistent with each other.
+     */
+    private void attributeQueueWaitToFirstStage(long queueWaitMillis) {
+        StageNodeExt firstStage = stages.peekFirst();
+        if (firstStage == null) {
+            return;
+        }
+        firstStage.setQueueDurationMillis(firstStage.getQueueDurationMillis() + queueWaitMillis);
+        // Removed the line that reduces the duration of the first stage
     }
 
     @Override

--- a/rest-api/src/main/java/com/cloudbees/workflow/rest/external/FlowNodeExt.java
+++ b/rest-api/src/main/java/com/cloudbees/workflow/rest/external/FlowNodeExt.java
@@ -57,6 +57,7 @@ public class FlowNodeExt {
     private long startTimeMillis;
     private long durationMillis;
     private long pauseDurationMillis;
+    private long queueDurationMillis;
 
     @JsonInclude(JsonInclude.Include.NON_NULL)
     public FlowNodeLinks get_links() {
@@ -140,6 +141,14 @@ public class FlowNodeExt {
 
     public void setPauseDurationMillis(long pauseDurationMillis) {
         this.pauseDurationMillis = pauseDurationMillis;
+    }
+
+    public long getQueueDurationMillis() {
+        return queueDurationMillis;
+    }
+
+    public void setQueueDurationMillis(long queueDurationMillis) {
+        this.queueDurationMillis = queueDurationMillis;
     }
 
     public static final class FlowNodeLinks extends Links {

--- a/rest-api/src/main/java/com/cloudbees/workflow/rest/external/RunExt.java
+++ b/rest-api/src/main/java/com/cloudbees/workflow/rest/external/RunExt.java
@@ -333,11 +333,15 @@ public class RunExt {
             runExt.setEndTimeMillis(run.getStartTimeInMillis()+run.getDuration());
         }
 
-        // Run has a timestamp when enqueued, and start time when it gets and Executor and begins running
+        StageNodeExt firstExecutedStage = runExt.getFirstExecutedStage();
         if (run.hasntStartedYet()) {
             runExt.setQueueDurationMillis(currentTimeMillis - run.getTimeInMillis());  // Enqueued time, not runtime
+        } else if (firstExecutedStage != null) {
+            runExt.setQueueDurationMillis(Math.max(0, firstExecutedStage.getStartTimeMillis() - run.getTimeInMillis()));
+        } else if (runExt.getStatus() == StatusExt.IN_PROGRESS || runExt.getStatus() == StatusExt.PAUSED_PENDING_INPUT) {
+            runExt.setQueueDurationMillis(Math.max(0, currentTimeMillis - run.getTimeInMillis()));
         } else {
-            runExt.setQueueDurationMillis(Math.max(0, run.getStartTimeInMillis()-run.getTimeInMillis()));
+            runExt.setQueueDurationMillis(Math.max(0, run.getStartTimeInMillis() - run.getTimeInMillis()));
         }
 
         runExt.setDurationMillis(Math.max(0, runExt.getEndTimeMillis() - runExt.getStartTimeMillis()));

--- a/rest-api/src/main/java/com/cloudbees/workflow/rest/external/StageNodeExt.java
+++ b/rest-api/src/main/java/com/cloudbees/workflow/rest/external/StageNodeExt.java
@@ -81,6 +81,7 @@ public class StageNodeExt extends FlowNodeExt {
         public long getStartTimeMillis() {return myNode.getStartTimeMillis();}
         public long getDurationMillis() {return myNode.getDurationMillis();}
         public long getPauseDurationMillis() {return myNode.getPauseDurationMillis();}
+        public long getQueueDurationMillis() {return myNode.getQueueDurationMillis();}
 
         @Override
         public List<AtomFlowNodeExt> getStageFlowNodes() {

--- a/rest-api/src/test/java/com/cloudbees/workflow/rest/endpoints/FlowNodeAPITest.java
+++ b/rest-api/src/test/java/com/cloudbees/workflow/rest/endpoints/FlowNodeAPITest.java
@@ -90,6 +90,7 @@ public class FlowNodeAPITest {
         Assert.assertEquals(1, workflowRuns.length);
         Assert.assertEquals("#1", workflowRuns[0].getName());
         Assert.assertEquals(StatusExt.SUCCESS, workflowRuns[0].getStatus());
+        Assert.assertTrue("Run queue duration should be sane", workflowRuns[0].getQueueDurationMillis() >= 0);
 
         // Test the endpoints
         assert_describe_ok(webClient, jsonReadWrite, workflowRuns);
@@ -114,6 +115,7 @@ public class FlowNodeAPITest {
         Assert.assertEquals("Build", stageDesc.getName());
         Assert.assertEquals(StatusExt.SUCCESS, stageDesc.getStatus());
         Assert.assertEquals("/jenkins/job/Noddy%20Job/1/execution/node/6/wfapi/describe", stageDesc.get_links().self.href);
+        Assert.assertTrue("Stage queue duration should be sane", stageDesc.getQueueDurationMillis() >= 0);
         Assert.assertEquals(1, stageDesc.getStageFlowNodes().size());
         Assert.assertEquals("7", stageDesc.getStageFlowNodes().get(0).getId());
         Assert.assertEquals("Print Message", stageDesc.getStageFlowNodes().get(0).getName());

--- a/rest-api/src/test/java/com/cloudbees/workflow/rest/endpoints/JobAndRunAPITest.java
+++ b/rest-api/src/test/java/com/cloudbees/workflow/rest/endpoints/JobAndRunAPITest.java
@@ -112,6 +112,9 @@ public class JobAndRunAPITest {
         Assert.assertEquals(1, workflowRuns.length);
         RunExt runExt = workflowRuns[0];
         assertRunInfoOkay(job, runExt, 6, 11, 16);
+        Assert.assertEquals("Run queue duration should extend to the first executed stage",
+            Math.max(0, runExt.getStages().get(0).getStartTimeMillis() - build.get().getTimeInMillis()),
+            runExt.getQueueDurationMillis());
 
         /** Test the describe endpoint, similar to {@link #assertDescribeEndpointOkay(WorkflowJob, JenkinsRule.WebClient)} */
         String descUrl = job.getUrl() + "1/wfapi/describe";
@@ -119,6 +122,9 @@ public class JobAndRunAPITest {
         jsonResponse = runsPage.getWebResponse().getContentAsString();
         RunExt workflowRun = jsonReadWrite.fromString(jsonResponse, RunExt.class);
         assertRunInfoOkay(job, workflowRun, 6, 11, 16);
+        Assert.assertEquals("Describe endpoint should report queue duration through the first executed stage",
+            Math.max(0, workflowRun.getStages().get(0).getStartTimeMillis() - build.get().getTimeInMillis()),
+            workflowRun.getQueueDurationMillis());
 
         // Run another build and then test resultset narrowing using the 'since' query parameter
         build = job.scheduleBuild2(0);


### PR DESCRIPTION
Fix queueDurationMillis calculation to flow and stage node REST models, compute run queue time from the first executed stage when available, and carry queue wait detected inside node blocks into stage timing data.

https://issues.jenkins.io/browse/JENKINS-49179


<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
